### PR TITLE
feat(phase-3a): TunnelProvider interface + mock + ADR

### DIFF
--- a/src/tunnel/mock-provider.ts
+++ b/src/tunnel/mock-provider.ts
@@ -1,0 +1,42 @@
+import type { TunnelProvider, TunnelConfig, Tunnel } from "./types.js";
+
+/**
+ * In-memory mock TunnelProvider for testing.
+ * Simulates connect/disconnect without any real SSH connections.
+ */
+export class MockTunnelProvider implements TunnelProvider {
+  private readonly tunnels = new Map<string, Tunnel>();
+
+  /** Simulate a forced disconnect (e.g. connection drop) */
+  simulateDrop(env: string): void {
+    const tunnel = this.tunnels.get(env);
+    if (tunnel) tunnel.status = "disconnected";
+  }
+
+  async connect(env: string, config: TunnelConfig): Promise<Tunnel> {
+    const existing = this.tunnels.get(env);
+    if (existing && existing.status === "active") return existing;
+
+    const tunnel: Tunnel = {
+      env,
+      local_port: config.local_port,
+      status: "active",
+      connected_at: new Date(),
+      last_query_at: new Date(),
+    };
+    this.tunnels.set(env, tunnel);
+    return tunnel;
+  }
+
+  async disconnect(env: string): Promise<void> {
+    this.tunnels.delete(env);
+  }
+
+  getStatus(env: string): Tunnel | null {
+    return this.tunnels.get(env) ?? null;
+  }
+
+  async disconnectAll(): Promise<void> {
+    this.tunnels.clear();
+  }
+}

--- a/src/tunnel/types.test.ts
+++ b/src/tunnel/types.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MockTunnelProvider } from "./mock-provider.js";
+import type { TunnelConfig } from "./types.js";
+
+const cfg: TunnelConfig = {
+  bastion: "bastion.example.com",
+  bastion_port: 22,
+  key_path: "~/.ssh/id_rsa",
+  local_port: 5433,
+  remote_host: "localhost",
+  remote_port: 5432,
+};
+
+describe("TunnelProvider contract (via MockTunnelProvider)", () => {
+  let provider: MockTunnelProvider;
+
+  beforeEach(() => {
+    provider = new MockTunnelProvider();
+  });
+
+  it("getStatus returns null before connect", () => {
+    expect(provider.getStatus("stage")).toBeNull();
+  });
+
+  it("connect returns active tunnel", async () => {
+    const tunnel = await provider.connect("stage", cfg);
+    expect(tunnel.env).toBe("stage");
+    expect(tunnel.status).toBe("active");
+    expect(tunnel.local_port).toBe(5433);
+  });
+
+  it("getStatus returns tunnel after connect", async () => {
+    await provider.connect("stage", cfg);
+    const status = provider.getStatus("stage");
+    expect(status).not.toBeNull();
+    expect(status?.status).toBe("active");
+  });
+
+  it("connect is idempotent — returns same tunnel on second call", async () => {
+    const t1 = await provider.connect("stage", cfg);
+    const t2 = await provider.connect("stage", cfg);
+    expect(t1).toBe(t2);
+  });
+
+  it("disconnect removes the tunnel", async () => {
+    await provider.connect("stage", cfg);
+    await provider.disconnect("stage");
+    expect(provider.getStatus("stage")).toBeNull();
+  });
+
+  it("disconnect is safe when tunnel does not exist", async () => {
+    await expect(provider.disconnect("nope")).resolves.toBeUndefined();
+  });
+
+  it("disconnectAll clears all tunnels", async () => {
+    await provider.connect("stage", cfg);
+    await provider.connect("prod", { ...cfg, local_port: 5434 });
+    await provider.disconnectAll();
+    expect(provider.getStatus("stage")).toBeNull();
+    expect(provider.getStatus("prod")).toBeNull();
+  });
+
+  it("simulateDrop sets status to disconnected", async () => {
+    await provider.connect("stage", cfg);
+    provider.simulateDrop("stage");
+    expect(provider.getStatus("stage")?.status).toBe("disconnected");
+  });
+
+  it("connect after drop creates a new active tunnel", async () => {
+    await provider.connect("stage", cfg);
+    provider.simulateDrop("stage");
+    const tunnel = await provider.connect("stage", cfg);
+    expect(tunnel.status).toBe("active");
+  });
+});

--- a/src/tunnel/types.ts
+++ b/src/tunnel/types.ts
@@ -1,0 +1,46 @@
+export type TunnelStatus = "active" | "idle" | "disconnected" | "connecting";
+
+export interface TunnelConfig {
+  /** SSH bastion hostname */
+  bastion: string;
+  /** SSH port on the bastion (default 22) */
+  bastion_port: number;
+  /** Path to SSH private key file */
+  key_path: string;
+  /** Local TCP port to bind — pg.Pool connects here */
+  local_port: number;
+  /** Target DB host as seen from the bastion (e.g. "localhost" or internal hostname) */
+  remote_host: string;
+  /** Target DB port as seen from the bastion */
+  remote_port: number;
+}
+
+export interface Tunnel {
+  /** Environment this tunnel belongs to */
+  env: string;
+  /** Local port that pg.Pool should connect to */
+  local_port: number;
+  /** Current status */
+  status: TunnelStatus;
+  /** When the tunnel was opened */
+  connected_at: Date;
+  /** Timestamp of the last query that used this tunnel */
+  last_query_at: Date;
+}
+
+export interface TunnelProvider {
+  /**
+   * Open a tunnel for the given env.
+   * No-op if a tunnel is already active for this env.
+   */
+  connect(env: string, config: TunnelConfig): Promise<Tunnel>;
+
+  /** Close the tunnel for the given env. No-op if not connected. */
+  disconnect(env: string): Promise<void>;
+
+  /** Returns current tunnel state, or null if no tunnel exists for this env. */
+  getStatus(env: string): Tunnel | null;
+
+  /** Close all open tunnels. */
+  disconnectAll(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

- `TunnelProvider` interface with `connect` / `disconnect` / `getStatus` / `disconnectAll`
- Supporting types: `TunnelConfig`, `Tunnel`, `TunnelStatus`
- `MockTunnelProvider` — in-memory implementation for contract testing
- 9 tests covering the full contract (idempotent connect, drop simulation, disconnectAll)
- ADR in `.planning/adr-ssh-tunnel.md`: chose `ssh2` directly (bundled types, stable, `forwardOut` + `net.Server` pattern for `pg.Pool` compatibility)

## Test plan

- [x] 66 tests total, all green
- [x] TypeScript strict, no errors

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)