### PR TITLE
feat(phase-3b): Ssh2TunnelProvider + lazy connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "pg": "^8.20.0",
+        "ssh2": "^1.17.0",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@types/node": "^25.5.0",
         "@types/pg": "^8.20.0",
+        "@types/ssh2": "^1.15.5",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.1",
@@ -922,6 +924,33 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -1123,6 +1152,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1131,6 +1169,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/body-parser": {
@@ -1155,6 +1202,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bytes": {
@@ -1317,6 +1373,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2381,6 +2451,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3066,6 +3143,23 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3212,6 +3306,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "pg": "^8.20.0",
+    "ssh2": "^1.17.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@types/pg": "^8.20.0",
+    "@types/ssh2": "^1.15.5",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,18 @@
 import * as z from "zod/v4";
 
+const TunnelConfigSchema = z.object({
+  bastion: z.string(),
+  bastion_port: z.number().default(22),
+  username: z.string(),
+  key_path: z.string(),
+  passphrase: z.string().optional(),
+  local_port: z.number(),
+  /** DB host as seen from the bastion. Defaults to env.host if omitted. */
+  remote_host: z.string().optional(),
+  /** DB port as seen from the bastion. Defaults to env.port if omitted. */
+  remote_port: z.number().optional(),
+});
+
 const EnvConfigSchema = z.object({
   host: z.string(),
   port: z.number().default(5432),
@@ -8,13 +21,7 @@ const EnvConfigSchema = z.object({
   password: z.string(),
   permissions: z.enum(["read-write", "read-only"]),
   approval: z.enum(["auto", "hitl"]),
-});
-
-const TunnelConfigSchema = z.object({
-  bastion: z.string(),
-  bastion_port: z.number().default(22),
-  key_path: z.string(),
-  local_port: z.number(),
+  tunnel: TunnelConfigSchema.optional(),
 });
 
 const SafetyConfigSchema = z.object({

--- a/src/router/connection-manager.test.ts
+++ b/src/router/connection-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { ConnectionManager } from "./connection-manager.js";
 import { UnknownEnvError, ConnectionError } from "../utils/errors.js";
+import { MockTunnelProvider } from "../tunnel/mock-provider.js";
 import { type Config } from "../config/schema.js";
 
 const sandboxConfig: Config = {
@@ -97,5 +98,75 @@ describe("ConnectionManager", () => {
     await tempManager.shutdown();
     // @ts-expect-error accessing private for test
     expect(tempManager.pools.size).toBe(0);
+  });
+});
+
+const tunnelConfig: Config = {
+  project: "test",
+  environments: {
+    dev: {
+      host: "localhost",
+      port: 5432,
+      database: "sandbox_dev",
+      user: "toad",
+      password: "toad_secret",
+      permissions: "read-write",
+      approval: "auto",
+    },
+    tunneled: {
+      host: "remote-db.internal",
+      port: 5432,
+      database: "sandbox_dev",
+      user: "toad",
+      password: "toad_secret",
+      permissions: "read-only",
+      approval: "auto",
+      tunnel: {
+        bastion: "bastion.example.com",
+        bastion_port: 22,
+        username: "deploy",
+        key_path: "~/.ssh/id_rsa",
+        local_port: 5432, // mock will redirect here — resolves to sandbox_dev
+        remote_host: "localhost",
+        remote_port: 5432,
+      },
+    },
+  },
+};
+
+describe("ConnectionManager with TunnelProvider", () => {
+  it("no tunnels open at startup — provider has 0 active tunnels", () => {
+    const provider = new MockTunnelProvider();
+    new ConnectionManager(tunnelConfig, provider);
+    expect(provider.getStatus("tunneled")).toBeNull();
+  });
+
+  it("tunnel opens lazily on first getPool() call for tunneled env", async () => {
+    const provider = new MockTunnelProvider();
+    const manager = new ConnectionManager(tunnelConfig, provider);
+
+    expect(provider.getStatus("tunneled")).toBeNull();
+    await manager.getPool("tunneled");
+    expect(provider.getStatus("tunneled")?.status).toBe("active");
+
+    await manager.shutdown();
+  });
+
+  it("non-tunneled env does not open a tunnel", async () => {
+    const provider = new MockTunnelProvider();
+    const manager = new ConnectionManager(tunnelConfig, provider);
+
+    await manager.getPool("dev");
+    expect(provider.getStatus("dev")).toBeNull();
+
+    await manager.shutdown();
+  });
+
+  it("shutdown calls disconnectAll on the tunnel provider", async () => {
+    const provider = new MockTunnelProvider();
+    const manager = new ConnectionManager(tunnelConfig, provider);
+    await manager.getPool("tunneled");
+    await manager.shutdown();
+    expect(provider.getStatus("tunneled")).toBeNull();
   });
 });

--- a/src/router/connection-manager.ts
+++ b/src/router/connection-manager.ts
@@ -1,13 +1,17 @@
 import pg from "pg";
 import { type Config, type EnvConfig } from "../config/schema.js";
 import { ConnectionError, UnknownEnvError } from "../utils/errors.js";
+import type { TunnelProvider, TunnelConfig } from "../tunnel/types.js";
 
 const { Pool } = pg;
 
 export class ConnectionManager {
   private readonly pools: Map<string, pg.Pool> = new Map();
 
-  constructor(private readonly config: Config) {}
+  constructor(
+    private readonly config: Config,
+    private readonly tunnelProvider?: TunnelProvider,
+  ) {}
 
   async getPool(env: string): Promise<pg.Pool> {
     const envConfig = this.config.environments[env];
@@ -16,9 +20,20 @@ export class ConnectionManager {
     }
 
     if (!this.pools.has(env)) {
+      // Open SSH tunnel lazily if this env requires one
+      let host = envConfig.host;
+      let port = envConfig.port;
+
+      if (envConfig.tunnel && this.tunnelProvider) {
+        const tunnelConfig = this.buildTunnelConfig(env, envConfig);
+        const tunnel = await this.tunnelProvider.connect(env, tunnelConfig);
+        host = "127.0.0.1";
+        port = tunnel.local_port;
+      }
+
       const pool = new Pool({
-        host: envConfig.host,
-        port: envConfig.port,
+        host,
+        port,
         database: envConfig.database,
         user: envConfig.user,
         password: envConfig.password,
@@ -55,5 +70,20 @@ export class ConnectionManager {
   async shutdown(): Promise<void> {
     await Promise.all([...this.pools.values()].map((pool) => pool.end()));
     this.pools.clear();
+    await this.tunnelProvider?.disconnectAll();
+  }
+
+  private buildTunnelConfig(env: string, envConfig: EnvConfig): TunnelConfig {
+    const t = envConfig.tunnel!;
+    return {
+      bastion: t.bastion,
+      bastion_port: t.bastion_port,
+      username: t.username,
+      key_path: t.key_path,
+      passphrase: t.passphrase,
+      local_port: t.local_port,
+      remote_host: t.remote_host ?? envConfig.host,
+      remote_port: t.remote_port ?? envConfig.port,
+    };
   }
 }

--- a/src/tunnel/ssh2-provider.test.ts
+++ b/src/tunnel/ssh2-provider.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { Ssh2TunnelProvider, TunnelError } from "./ssh2-provider.js";
+import type { TunnelConfig } from "./types.js";
+
+const unreachableCfg: TunnelConfig = {
+  bastion: "127.0.0.1",
+  bastion_port: 19999, // nothing listening here
+  username: "nobody",
+  key_path: "~/.ssh/nonexistent_key_xyz",
+  local_port: 15433,
+  remote_host: "localhost",
+  remote_port: 5432,
+};
+
+describe("Ssh2TunnelProvider", () => {
+  it("getStatus returns null before any connect", () => {
+    const provider = new Ssh2TunnelProvider();
+    expect(provider.getStatus("prod")).toBeNull();
+  });
+
+  it("throws TunnelError when key file does not exist", async () => {
+    const provider = new Ssh2TunnelProvider();
+    await expect(provider.connect("prod", unreachableCfg)).rejects.toThrow(
+      TunnelError,
+    );
+  });
+
+  it("TunnelError message includes env name", async () => {
+    const provider = new Ssh2TunnelProvider();
+    await expect(provider.connect("prod", unreachableCfg)).rejects.toThrow(
+      /prod/,
+    );
+  });
+
+  it("disconnect is safe when no tunnel exists", async () => {
+    const provider = new Ssh2TunnelProvider();
+    await expect(provider.disconnect("prod")).resolves.toBeUndefined();
+  });
+
+  it("disconnectAll is safe when no tunnels exist", async () => {
+    const provider = new Ssh2TunnelProvider();
+    await expect(provider.disconnectAll()).resolves.toBeUndefined();
+  });
+});

--- a/src/tunnel/ssh2-provider.ts
+++ b/src/tunnel/ssh2-provider.ts
@@ -1,0 +1,127 @@
+import net from "net";
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { Client } from "ssh2";
+import type { TunnelProvider, TunnelConfig, Tunnel } from "./types.js";
+import { ToadError } from "../utils/errors.js";
+
+export class TunnelError extends ToadError {
+  constructor(
+    public readonly env: string,
+    message: string,
+    cause?: unknown,
+  ) {
+    super(`Tunnel error for "${env}": ${message}`, cause);
+    this.name = "TunnelError";
+  }
+}
+
+interface ActiveTunnel {
+  tunnel: Tunnel;
+  conn: Client;
+  server: net.Server;
+}
+
+export class Ssh2TunnelProvider implements TunnelProvider {
+  private readonly active = new Map<string, ActiveTunnel>();
+
+  async connect(env: string, config: TunnelConfig): Promise<Tunnel> {
+    const existing = this.active.get(env);
+    if (existing && existing.tunnel.status === "active") {
+      return existing.tunnel;
+    }
+
+    return new Promise<Tunnel>((resolve, reject) => {
+      const conn = new Client();
+
+      const keyPath = config.key_path.replace(/^~/, homedir());
+      let privateKey: Buffer;
+      try {
+        privateKey = readFileSync(keyPath);
+      } catch (err) {
+        return reject(
+          new TunnelError(env, `Cannot read key file: ${keyPath}`, err),
+        );
+      }
+
+      conn
+        .on("ready", () => {
+          const server = net.createServer((socket) => {
+            conn.forwardOut(
+              "127.0.0.1",
+              0,
+              config.remote_host,
+              config.remote_port,
+              (err, stream) => {
+                if (err) {
+                  socket.destroy();
+                  return;
+                }
+                socket.pipe(stream).pipe(socket);
+                stream.on("close", () => socket.destroy());
+                socket.on("close", () => stream.destroy());
+              },
+            );
+          });
+
+          server.listen(config.local_port, "127.0.0.1", () => {
+            const tunnel: Tunnel = {
+              env,
+              local_port: config.local_port,
+              status: "active",
+              connected_at: new Date(),
+              last_query_at: new Date(),
+            };
+            this.active.set(env, { tunnel, conn, server });
+            resolve(tunnel);
+          });
+
+          server.on("error", (err) => {
+            conn.end();
+            reject(
+              new TunnelError(
+                env,
+                `Local server error on port ${config.local_port}`,
+                err,
+              ),
+            );
+          });
+        })
+        .on("error", (err) => {
+          reject(new TunnelError(env, "SSH connection error", err));
+        })
+        .connect({
+          host: config.bastion,
+          port: config.bastion_port,
+          username: config.username,
+          privateKey,
+          passphrase: config.passphrase,
+          readyTimeout: 10_000,
+        });
+    });
+  }
+
+  async disconnect(env: string): Promise<void> {
+    const active = this.active.get(env);
+    if (!active) return;
+
+    await new Promise<void>((resolve) => {
+      active.server.close(() => {
+        active.conn.end();
+        resolve();
+      });
+    });
+
+    this.active.delete(env);
+  }
+
+  getStatus(env: string): Tunnel | null {
+    return this.active.get(env)?.tunnel ?? null;
+  }
+
+  async disconnectAll(): Promise<void> {
+    await Promise.all(
+      [...this.active.keys()].map((env) => this.disconnect(env)),
+    );
+  }
+}

--- a/src/tunnel/types.test.ts
+++ b/src/tunnel/types.test.ts
@@ -5,6 +5,7 @@ import type { TunnelConfig } from "./types.js";
 const cfg: TunnelConfig = {
   bastion: "bastion.example.com",
   bastion_port: 22,
+  username: "deploy",
   key_path: "~/.ssh/id_rsa",
   local_port: 5433,
   remote_host: "localhost",

--- a/src/tunnel/types.ts
+++ b/src/tunnel/types.ts
@@ -5,8 +5,12 @@ export interface TunnelConfig {
   bastion: string;
   /** SSH port on the bastion (default 22) */
   bastion_port: number;
+  /** SSH username */
+  username: string;
   /** Path to SSH private key file */
   key_path: string;
+  /** Passphrase for encrypted private key (optional) */
+  passphrase?: string;
   /** Local TCP port to bind — pg.Pool connects here */
   local_port: number;
   /** Target DB host as seen from the bastion (e.g. "localhost" or internal hostname) */


### PR DESCRIPTION
## Summary

- `Ssh2TunnelProvider` — `net.Server` + `forwardOut` pattern so `pg.Pool` works transparently through SSH tunnels
- Auth: private key file (`key_path`) with optional `passphrase`
- `TunnelError` wraps all failure modes with env context
- `ConnectionManager` accepts optional `TunnelProvider`, opens tunnel lazily on first `getPool()` call
- Tunneled envs: pool connects to `127.0.0.1:local_port` instead of the remote host
- `shutdown()` closes pg pools then calls `disconnectAll()` on the provider
- Schema: added `username`, `passphrase`, `remote_host`, `remote_port` to `tunnel` config block

## Test plan

- [x] `Ssh2TunnelProvider`: 5 unit tests (key not found → TunnelError, safe disconnect, safe disconnectAll)
- [x] Lazy connect: 4 integration tests via `MockTunnelProvider` (0 tunnels at startup, opens on first query, non-tunneled env skips provider, shutdown cleans up)
- [x] 75 tests total, all green
- [x] TypeScript strict, no errors

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)