### PR TITLE
feat(phase-3c): keep-alive, idle timeout & reconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadConfig } from "./config/loader.js";
 import { ConnectionManager } from "./router/connection-manager.js";
+import { Ssh2TunnelProvider } from "./tunnel/ssh2-provider.js";
 import { SchemaCache } from "./schema/cache.js";
 import { registerExecuteQuery } from "./tools/execute-query.js";
 import { registerListNodes } from "./tools/list-nodes.js";
@@ -11,7 +12,15 @@ import { registerDescribeColumns } from "./tools/describe-columns.js";
 const CONFIG_PATH = process.env["TOAD_CONFIG"] ?? "config/toad-tunnel.yaml";
 
 const config = loadConfig(CONFIG_PATH);
-const connectionManager = new ConnectionManager(config);
+
+// Wire onReconnect callback: tunnelProvider notifies manager to drop stale pool
+let connectionManager: ConnectionManager;
+const tunnelProvider = new Ssh2TunnelProvider({
+  ...config.tunnels,
+  onReconnect: (env) => connectionManager.invalidatePool(env),
+});
+connectionManager = new ConnectionManager(config, tunnelProvider);
+
 const schemaCache = new SchemaCache();
 
 const server = new McpServer({

--- a/src/router/connection-manager.test.ts
+++ b/src/router/connection-manager.test.ts
@@ -169,4 +169,32 @@ describe("ConnectionManager with TunnelProvider", () => {
     await manager.shutdown();
     expect(provider.getStatus("tunneled")).toBeNull();
   });
+
+  it("invalidatePool removes the cached pool", async () => {
+    const provider = new MockTunnelProvider();
+    const manager = new ConnectionManager(tunnelConfig, provider);
+    const pool1 = await manager.getPool("tunneled");
+    manager.invalidatePool("tunneled");
+    // @ts-expect-error accessing private for test
+    expect(manager.pools.has("tunneled")).toBe(false);
+    const pool2 = await manager.getPool("tunneled");
+    expect(pool2).not.toBe(pool1);
+    await manager.shutdown();
+  });
+
+  it("onReconnect callback invalidates and recreates pool", async () => {
+    let onReconnect: (env: string) => void = () => {};
+    const provider = new MockTunnelProvider();
+    const manager = new ConnectionManager(tunnelConfig, provider);
+    // Manually wire the callback (as index.ts would do)
+    onReconnect = (env) => manager.invalidatePool(env);
+
+    const pool1 = await manager.getPool("tunneled");
+    onReconnect("tunneled");
+    // @ts-expect-error accessing private for test
+    expect(manager.pools.has("tunneled")).toBe(false);
+    const pool2 = await manager.getPool("tunneled");
+    expect(pool2).not.toBe(pool1);
+    await manager.shutdown();
+  });
 });

--- a/src/router/connection-manager.ts
+++ b/src/router/connection-manager.ts
@@ -57,6 +57,15 @@ export class ConnectionManager {
     return this.pools.get(env)!;
   }
 
+  /** Called by TunnelProvider.onReconnect to force pool recreation on next getPool() */
+  invalidatePool(env: string): void {
+    const pool = this.pools.get(env);
+    if (pool) {
+      void pool.end().catch(() => {});
+      this.pools.delete(env);
+    }
+  }
+
   getEnvNames(): string[] {
     return Object.keys(this.config.environments);
   }

--- a/src/tunnel/lifecycle.test.ts
+++ b/src/tunnel/lifecycle.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { IdleTracker } from "./lifecycle.js";
+
+describe("IdleTracker", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not fire onIdle before timeout", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    vi.advanceTimersByTime(999);
+    expect(onIdle).not.toHaveBeenCalled();
+    tracker.stopAll();
+  });
+
+  it("fires onIdle after idle_timeout_ms", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    vi.advanceTimersByTime(1_001);
+    expect(onIdle).toHaveBeenCalledWith("stage");
+    tracker.stopAll();
+  });
+
+  it("touch() resets the idle clock", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    vi.advanceTimersByTime(800);
+    tracker.touch("stage"); // reset
+    vi.advanceTimersByTime(800); // total 1600ms but only 800ms since touch
+    expect(onIdle).not.toHaveBeenCalled();
+    tracker.stopAll();
+  });
+
+  it("onIdle fires after timeout post-touch", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    vi.advanceTimersByTime(800);
+    tracker.touch("stage");
+    vi.advanceTimersByTime(1_200); // 1200ms after touch — fires
+    expect(onIdle).toHaveBeenCalledWith("stage");
+    tracker.stopAll();
+  });
+
+  it("start() is idempotent — second call does not create a second timer", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    tracker.start("stage"); // second call
+    vi.advanceTimersByTime(1_100);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+    tracker.stopAll();
+  });
+
+  it("stop() prevents onIdle from firing", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    tracker.stop("stage");
+    vi.advanceTimersByTime(2_000);
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it("stopAll() stops all envs", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    tracker.start("prod");
+    tracker.stopAll();
+    vi.advanceTimersByTime(2_000);
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it("tracks multiple envs independently", () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const tracker = new IdleTracker(1_000, onIdle);
+    tracker.start("stage");
+    tracker.start("prod");
+    vi.advanceTimersByTime(800);
+    tracker.touch("stage"); // only stage gets reset
+    vi.advanceTimersByTime(300); // prod hits 1100ms → idle; stage at 300ms
+    expect(onIdle).toHaveBeenCalledWith("prod");
+    expect(onIdle).not.toHaveBeenCalledWith("stage");
+    tracker.stopAll();
+  });
+});

--- a/src/tunnel/lifecycle.ts
+++ b/src/tunnel/lifecycle.ts
@@ -1,0 +1,69 @@
+export interface TunnelLifecycleOptions {
+  /** SSH keepalive interval in ms (default 30s) */
+  keepalive_interval_ms: number;
+  /** Close tunnel after this many ms of inactivity (default 5min) */
+  idle_timeout_ms: number;
+  /** Max SSH reconnect attempts on unexpected drop (default 3) */
+  max_retries: number;
+  /** Base delay for exponential backoff in ms (default 2s) */
+  retry_delay_ms: number;
+  /** Called after a tunnel successfully reconnects */
+  onReconnect?: (env: string) => void;
+  /** Called when all reconnect retries are exhausted */
+  onGiveUp?: (env: string) => void;
+}
+
+export const DEFAULT_LIFECYCLE: TunnelLifecycleOptions = {
+  keepalive_interval_ms: 30_000,
+  idle_timeout_ms: 300_000,
+  max_retries: 3,
+  retry_delay_ms: 2_000,
+};
+
+/**
+ * Tracks last-activity time per env and fires onIdle when idle_timeout_ms elapses.
+ * Decoupled from SSH logic so it can be tested with fake timers.
+ */
+export class IdleTracker {
+  private readonly lastActivity = new Map<string, number>();
+  private readonly timers = new Map<string, ReturnType<typeof setInterval>>();
+
+  constructor(
+    private readonly idleTimeoutMs: number,
+    private readonly onIdle: (env: string) => void,
+  ) {}
+
+  start(env: string): void {
+    this.touch(env);
+    if (this.timers.has(env)) return;
+
+    const timer = setInterval(() => {
+      const last = this.lastActivity.get(env) ?? Date.now();
+      if (Date.now() - last >= this.idleTimeoutMs) {
+        this.stop(env);
+        this.onIdle(env);
+      }
+    }, this.idleTimeoutMs);
+
+    this.timers.set(env, timer);
+  }
+
+  touch(env: string): void {
+    this.lastActivity.set(env, Date.now());
+  }
+
+  stop(env: string): void {
+    const timer = this.timers.get(env);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(env);
+    }
+    this.lastActivity.delete(env);
+  }
+
+  stopAll(): void {
+    for (const env of [...this.timers.keys()]) {
+      this.stop(env);
+    }
+  }
+}

--- a/src/tunnel/ssh2-provider.ts
+++ b/src/tunnel/ssh2-provider.ts
@@ -3,6 +3,11 @@ import { readFileSync } from "fs";
 import { homedir } from "os";
 import { Client } from "ssh2";
 import type { TunnelProvider, TunnelConfig, Tunnel } from "./types.js";
+import {
+  IdleTracker,
+  DEFAULT_LIFECYCLE,
+  type TunnelLifecycleOptions,
+} from "./lifecycle.js";
 import { ToadError } from "../utils/errors.js";
 
 export class TunnelError extends ToadError {
@@ -20,10 +25,22 @@ interface ActiveTunnel {
   tunnel: Tunnel;
   conn: Client;
   server: net.Server;
+  config: TunnelConfig;
+  intentionalClose: boolean;
+  retryCount: number;
 }
 
 export class Ssh2TunnelProvider implements TunnelProvider {
   private readonly active = new Map<string, ActiveTunnel>();
+  private readonly opts: TunnelLifecycleOptions;
+  private readonly idle: IdleTracker;
+
+  constructor(opts: Partial<TunnelLifecycleOptions> = {}) {
+    this.opts = { ...DEFAULT_LIFECYCLE, ...opts };
+    this.idle = new IdleTracker(this.opts.idle_timeout_ms, (env) => {
+      void this.disconnect(env);
+    });
+  }
 
   async connect(env: string, config: TunnelConfig): Promise<Tunnel> {
     const existing = this.active.get(env);
@@ -31,6 +48,10 @@ export class Ssh2TunnelProvider implements TunnelProvider {
       return existing.tunnel;
     }
 
+    return this._openConnection(env, config);
+  }
+
+  private _openConnection(env: string, config: TunnelConfig): Promise<Tunnel> {
     return new Promise<Tunnel>((resolve, reject) => {
       const conn = new Client();
 
@@ -47,6 +68,10 @@ export class Ssh2TunnelProvider implements TunnelProvider {
       conn
         .on("ready", () => {
           const server = net.createServer((socket) => {
+            this.idle.touch(env);
+            const active = this.active.get(env);
+            if (active) active.tunnel.last_query_at = new Date();
+
             conn.forwardOut(
               "127.0.0.1",
               0,
@@ -72,7 +97,16 @@ export class Ssh2TunnelProvider implements TunnelProvider {
               connected_at: new Date(),
               last_query_at: new Date(),
             };
-            this.active.set(env, { tunnel, conn, server });
+            const record: ActiveTunnel = {
+              tunnel,
+              conn,
+              server,
+              config,
+              intentionalClose: false,
+              retryCount: 0,
+            };
+            this.active.set(env, record);
+            this.idle.start(env);
             resolve(tunnel);
           });
 
@@ -90,6 +124,12 @@ export class Ssh2TunnelProvider implements TunnelProvider {
         .on("error", (err) => {
           reject(new TunnelError(env, "SSH connection error", err));
         })
+        .on("close", () => {
+          const record = this.active.get(env);
+          if (record && !record.intentionalClose) {
+            void this._scheduleReconnect(env, record);
+          }
+        })
         .connect({
           host: config.bastion,
           port: config.bastion_port,
@@ -97,13 +137,62 @@ export class Ssh2TunnelProvider implements TunnelProvider {
           privateKey,
           passphrase: config.passphrase,
           readyTimeout: 10_000,
+          keepaliveInterval: this.opts.keepalive_interval_ms,
+          keepaliveCountMax: 3,
         });
     });
+  }
+
+  private async _scheduleReconnect(
+    env: string,
+    record: ActiveTunnel,
+  ): Promise<void> {
+    if (record.retryCount >= this.opts.max_retries) {
+      record.tunnel.status = "disconnected";
+      this.idle.stop(env);
+      this.opts.onGiveUp?.(env);
+      this.active.delete(env);
+      return;
+    }
+
+    record.tunnel.status = "connecting";
+    record.retryCount += 1;
+    const delay = this.opts.retry_delay_ms * Math.pow(2, record.retryCount - 1);
+
+    await new Promise<void>((r) => setTimeout(r, delay));
+
+    // Close the old net.Server before reopening
+    await new Promise<void>((resolve) => {
+      record.server.close(() => resolve());
+    });
+
+    this.active.delete(env);
+
+    try {
+      await this._openConnection(env, record.config);
+      const reconnected = this.active.get(env);
+      if (reconnected) reconnected.retryCount = 0;
+      this.opts.onReconnect?.(env);
+    } catch {
+      // _openConnection already set status; _scheduleReconnect will be called
+      // again via the 'close' event on the new conn if it connects and then drops.
+      // If it never connects, reject() is called and we give up here.
+      const stale = this.active.get(env);
+      if (stale && stale.retryCount < this.opts.max_retries) {
+        void this._scheduleReconnect(env, stale);
+      } else {
+        this.opts.onGiveUp?.(env);
+        this.active.delete(env);
+      }
+    }
   }
 
   async disconnect(env: string): Promise<void> {
     const active = this.active.get(env);
     if (!active) return;
+
+    active.intentionalClose = true;
+    this.idle.stop(env);
 
     await new Promise<void>((resolve) => {
       active.server.close(() => {
@@ -120,6 +209,7 @@ export class Ssh2TunnelProvider implements TunnelProvider {
   }
 
   async disconnectAll(): Promise<void> {
+    this.idle.stopAll();
     await Promise.all(
       [...this.active.keys()].map((env) => this.disconnect(env)),
     );


### PR DESCRIPTION
## Summary

- **`IdleTracker`** — decoupled per-env idle timer with `touch()` / `stop()` / `stopAll()`. Fires `onIdle(env)` after `idle_timeout_ms` of inactivity. Fully testable with `vi.useFakeTimers()`.
- **Keep-alive** — `keepaliveInterval` + `keepaliveCountMax` passed to ssh2 `connect()`. No additional logic needed.
- **Idle disconnect** — `last_query_at` updated on every socket connect to the `net.Server`. `IdleTracker` fires `disconnect(env)` after inactivity.
- **Reconnect loop** — on unexpected SSH `'close'`, closes old `net.Server`, waits `retry_delay_ms * 2^attempt`, retries up to `max_retries`. Calls `onReconnect(env)` on success, `onGiveUp(env)` when retries exhausted.
- **Status transitions** — `active` → `connecting` (mid-reconnect) → `active` / `disconnected`
- **`ConnectionManager.invalidatePool(env)`** — drops the cached `pg.Pool` so next `getPool()` recreates it. Wired to `onReconnect` in `index.ts` via lazy callback.

## Test plan

- [x] `IdleTracker`: 8 unit tests (fake timers) — fires, touch resets, stop prevents, stopAll, multi-env independent
- [x] `ConnectionManager`: `invalidatePool` recreates pool; `onReconnect` callback wiring
- [x] 85 tests total, all green
- [x] TypeScript strict, no errors

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)