### PR TITLE
refactor: code review fixes — DRY, KISS, arch improvements

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,7 +32,7 @@ const SafetyConfigSchema = z.object({
 export const ConfigSchema = z.object({
   project: z.string(),
   environments: z.record(z.string(), EnvConfigSchema),
-  tunnels: z
+  tunnel_options: z
     .object({
       idle_timeout_ms: z.number().default(300_000),
       keepalive_interval_ms: z.number().default(30_000),

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,16 @@ const CONFIG_PATH = process.env["TOAD_CONFIG"] ?? "config/toad-tunnel.yaml";
 
 const config = loadConfig(CONFIG_PATH);
 
-// Wire onReconnect callback: tunnelProvider notifies manager to drop stale pool
-let connectionManager: ConnectionManager;
-const tunnelProvider = new Ssh2TunnelProvider({
-  ...config.tunnels,
-  onReconnect: (env) => connectionManager.invalidatePool(env),
-});
-connectionManager = new ConnectionManager(config, tunnelProvider);
+const hasTunnels = Object.values(config.environments).some((e) => e.tunnel);
+const tunnelProvider = hasTunnels
+  ? new Ssh2TunnelProvider(config.tunnel_options)
+  : undefined;
+const connectionManager = new ConnectionManager(config, tunnelProvider);
+
+// Wire onReconnect: tunnel provider notifies manager to drop stale pool
+if (tunnelProvider) {
+  tunnelProvider.onReconnect = (env) => connectionManager.invalidatePool(env);
+}
 
 const schemaCache = new SchemaCache();
 
@@ -33,7 +36,9 @@ registerListNodes(server, connectionManager);
 registerGetOverview(server, connectionManager, schemaCache);
 registerDescribeColumns(server, connectionManager, schemaCache);
 registerExecuteQuery(server, connectionManager);
-registerTunnelStatus(server, connectionManager, tunnelProvider);
+if (tunnelProvider) {
+  registerTunnelStatus(server, connectionManager, tunnelProvider);
+}
 
 process.on("SIGINT", async () => {
   await connectionManager.shutdown();

--- a/src/tools/describe-columns.ts
+++ b/src/tools/describe-columns.ts
@@ -4,7 +4,8 @@ import { type ConnectionManager } from "../router/connection-manager.js";
 import { type SchemaCache } from "../schema/cache.js";
 import { queryColumns } from "../schema/queries.js";
 import { formatColumnsCompact } from "../schema/formatter.js";
-import { ToadError } from "../utils/errors.js";
+import { toolError } from "../utils/tool-result.js";
+import { envEnum } from "../utils/env-enum.js";
 
 export function registerDescribeColumns(
   server: McpServer,
@@ -21,9 +22,7 @@ export function registerDescribeColumns(
         "Results are cached for 5 minutes. " +
         `Available environments: ${envNames.join(", ")}.`,
       inputSchema: z.object({
-        env: z
-          .enum(envNames as [string, ...string[]])
-          .describe("Target environment"),
+        env: envEnum(envNames).describe("Target environment"),
         schema: z.string().default("public").describe("PostgreSQL schema name"),
         table: z.string().describe("Table name"),
       }),
@@ -33,7 +32,7 @@ export function registerDescribeColumns(
         const cacheKey = `columns:${env}:${schema}.${table}`;
         const cached = cache.get<string>(cacheKey);
         if (cached) {
-          return { content: [{ type: "text" as const, text: cached }] };
+          return { content: [{ type: "text", text: cached }] };
         }
 
         const pool = await connectionManager.getPool(env);
@@ -43,7 +42,7 @@ export function registerDescribeColumns(
           return {
             content: [
               {
-                type: "text" as const,
+                type: "text",
                 text: `Table "${schema}.${table}" not found or has no columns`,
               },
             ],
@@ -53,13 +52,9 @@ export function registerDescribeColumns(
 
         const text = formatColumnsCompact(columns);
         cache.set(cacheKey, text);
-        return { content: [{ type: "text" as const, text }] };
+        return { content: [{ type: "text", text }] };
       } catch (err) {
-        const message = err instanceof ToadError ? err.message : String(err);
-        return {
-          content: [{ type: "text" as const, text: `Error: ${message}` }],
-          isError: true,
-        };
+        return toolError(err);
       }
     },
   );

--- a/src/tools/execute-query.ts
+++ b/src/tools/execute-query.ts
@@ -2,7 +2,8 @@ import * as z from "zod/v4";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type ConnectionManager } from "../router/connection-manager.js";
 import { executeQuery } from "../router/query-executor.js";
-import { ToadError } from "../utils/errors.js";
+import { toolError } from "../utils/tool-result.js";
+import { envEnum } from "../utils/env-enum.js";
 
 export function registerExecuteQuery(
   server: McpServer,
@@ -18,9 +19,7 @@ export function registerExecuteQuery(
         `Available environments: ${envNames.join(", ")}. ` +
         "The database is resolved automatically from the environment config.",
       inputSchema: z.object({
-        env: z
-          .enum(envNames as [string, ...string[]])
-          .describe("Target environment"),
+        env: envEnum(envNames).describe("Target environment"),
         sql: z.string().describe("SQL query to execute"),
       }),
     },
@@ -32,15 +31,9 @@ export function registerExecuteQuery(
             ? "(no rows)"
             : result.rows.map((row) => JSON.stringify(row)).join("\n");
 
-        return {
-          content: [{ type: "text" as const, text }],
-        };
+        return { content: [{ type: "text", text }] };
       } catch (err) {
-        const message = err instanceof ToadError ? err.message : String(err);
-        return {
-          content: [{ type: "text" as const, text: `Error: ${message}` }],
-          isError: true,
-        };
+        return toolError(err);
       }
     },
   );

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -4,7 +4,8 @@ import { type ConnectionManager } from "../router/connection-manager.js";
 import { type SchemaCache } from "../schema/cache.js";
 import { queryTables } from "../schema/queries.js";
 import { formatTablesAsTsv } from "../schema/formatter.js";
-import { ToadError } from "../utils/errors.js";
+import { toolError } from "../utils/tool-result.js";
+import { envEnum } from "../utils/env-enum.js";
 
 export function registerGetOverview(
   server: McpServer,
@@ -21,9 +22,7 @@ export function registerGetOverview(
         "Results are cached for 5 minutes. " +
         `Available environments: ${envNames.join(", ")}.`,
       inputSchema: z.object({
-        env: z
-          .enum(envNames as [string, ...string[]])
-          .describe("Target environment"),
+        env: envEnum(envNames).describe("Target environment"),
       }),
     },
     async ({ env }) => {
@@ -31,7 +30,7 @@ export function registerGetOverview(
         const cacheKey = `overview:${env}`;
         const cached = cache.get<string>(cacheKey);
         if (cached) {
-          return { content: [{ type: "text" as const, text: cached }] };
+          return { content: [{ type: "text", text: cached }] };
         }
 
         const pool = await connectionManager.getPool(env);
@@ -39,13 +38,9 @@ export function registerGetOverview(
         const text = formatTablesAsTsv(tables);
 
         cache.set(cacheKey, text);
-        return { content: [{ type: "text" as const, text }] };
+        return { content: [{ type: "text", text }] };
       } catch (err) {
-        const message = err instanceof ToadError ? err.message : String(err);
-        return {
-          content: [{ type: "text" as const, text: `Error: ${message}` }],
-          isError: true,
-        };
+        return toolError(err);
       }
     },
   );

--- a/src/tools/list-nodes.ts
+++ b/src/tools/list-nodes.ts
@@ -1,14 +1,12 @@
 import * as z from "zod/v4";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type ConnectionManager } from "../router/connection-manager.js";
-import { ToadError } from "../utils/errors.js";
+import { toolError } from "../utils/tool-result.js";
 
 export function registerListNodes(
   server: McpServer,
   connectionManager: ConnectionManager,
 ): void {
-  const envNames = connectionManager.getEnvNames();
-
   server.registerTool(
     "toad_tunnel__list_nodes",
     {
@@ -21,22 +19,15 @@ export function registerListNodes(
     async () => {
       try {
         const lines: string[] = ["env\tdatabase\tpermissions\tapproval"];
-        for (const env of envNames) {
-          // Access config through connection manager
+        for (const env of connectionManager.getEnvNames()) {
           const cfg = connectionManager.getEnvConfig(env);
           lines.push(
             `${env}\t${cfg.database}\t${cfg.permissions}\t${cfg.approval}`,
           );
         }
-        return {
-          content: [{ type: "text" as const, text: lines.join("\n") }],
-        };
+        return { content: [{ type: "text", text: lines.join("\n") }] };
       } catch (err) {
-        const message = err instanceof ToadError ? err.message : String(err);
-        return {
-          content: [{ type: "text" as const, text: `Error: ${message}` }],
-          isError: true,
-        };
+        return toolError(err);
       }
     },
   );

--- a/src/tools/tunnel-status.ts
+++ b/src/tools/tunnel-status.ts
@@ -2,14 +2,13 @@ import * as z from "zod/v4";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type ConnectionManager } from "../router/connection-manager.js";
 import { type TunnelProvider } from "../tunnel/types.js";
+import { toolError } from "../utils/tool-result.js";
 
 export function registerTunnelStatus(
   server: McpServer,
   connectionManager: ConnectionManager,
   tunnelProvider: TunnelProvider,
 ): void {
-  const envNames = connectionManager.getEnvNames();
-
   server.registerTool(
     "toad_tunnel__tunnel_status",
     {
@@ -20,35 +19,37 @@ export function registerTunnelStatus(
       inputSchema: z.object({}),
     },
     async () => {
-      const lines: string[] = [
-        "env\tstatus\tlocal_port\tuptime_s\tlast_query_at",
-      ];
+      try {
+        const lines: string[] = [
+          "env\tstatus\tlocal_port\tuptime_s\tlast_query_at",
+        ];
 
-      for (const env of envNames) {
-        const cfg = connectionManager.getEnvConfig(env);
-        if (!cfg.tunnel) {
-          lines.push(`${env}\tnone\t-\t-\t-`);
-          continue;
+        for (const env of connectionManager.getEnvNames()) {
+          const cfg = connectionManager.getEnvConfig(env);
+          if (!cfg.tunnel) {
+            lines.push(`${env}\tnone\t-\t-\t-`);
+            continue;
+          }
+
+          const tunnel = tunnelProvider.getStatus(env);
+          if (!tunnel) {
+            lines.push(`${env}\tdisconnected\t${cfg.tunnel.local_port}\t-\t-`);
+            continue;
+          }
+
+          const uptimeSec = Math.floor(
+            (Date.now() - tunnel.connected_at.getTime()) / 1000,
+          );
+          const lastQuery = tunnel.last_query_at.toISOString();
+          lines.push(
+            `${env}\t${tunnel.status}\t${tunnel.local_port}\t${uptimeSec}\t${lastQuery}`,
+          );
         }
 
-        const tunnel = tunnelProvider.getStatus(env);
-        if (!tunnel) {
-          lines.push(`${env}\tdisconnected\t${cfg.tunnel.local_port}\t-\t-`);
-          continue;
-        }
-
-        const uptimeSec = Math.floor(
-          (Date.now() - tunnel.connected_at.getTime()) / 1000,
-        );
-        const lastQuery = tunnel.last_query_at.toISOString();
-        lines.push(
-          `${env}\t${tunnel.status}\t${tunnel.local_port}\t${uptimeSec}\t${lastQuery}`,
-        );
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (err) {
+        return toolError(err);
       }
-
-      return {
-        content: [{ type: "text" as const, text: lines.join("\n") }],
-      };
     },
   );
 }

--- a/src/tunnel/lifecycle.ts
+++ b/src/tunnel/lifecycle.ts
@@ -7,8 +7,6 @@ export interface TunnelLifecycleOptions {
   max_retries: number;
   /** Base delay for exponential backoff in ms (default 2s) */
   retry_delay_ms: number;
-  /** Called after a tunnel successfully reconnects */
-  onReconnect?: (env: string) => void;
   /** Called when all reconnect retries are exhausted */
   onGiveUp?: (env: string) => void;
 }
@@ -22,11 +20,12 @@ export const DEFAULT_LIFECYCLE: TunnelLifecycleOptions = {
 
 /**
  * Tracks last-activity time per env and fires onIdle when idle_timeout_ms elapses.
+ * Uses setTimeout with remaining-time recalculation for precise idle detection.
  * Decoupled from SSH logic so it can be tested with fake timers.
  */
 export class IdleTracker {
   private readonly lastActivity = new Map<string, number>();
-  private readonly timers = new Map<string, ReturnType<typeof setInterval>>();
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
 
   constructor(
     private readonly idleTimeoutMs: number,
@@ -36,16 +35,7 @@ export class IdleTracker {
   start(env: string): void {
     this.touch(env);
     if (this.timers.has(env)) return;
-
-    const timer = setInterval(() => {
-      const last = this.lastActivity.get(env) ?? Date.now();
-      if (Date.now() - last >= this.idleTimeoutMs) {
-        this.stop(env);
-        this.onIdle(env);
-      }
-    }, this.idleTimeoutMs);
-
-    this.timers.set(env, timer);
+    this._scheduleCheck(env);
   }
 
   touch(env: string): void {
@@ -55,7 +45,7 @@ export class IdleTracker {
   stop(env: string): void {
     const timer = this.timers.get(env);
     if (timer) {
-      clearInterval(timer);
+      clearTimeout(timer);
       this.timers.delete(env);
     }
     this.lastActivity.delete(env);
@@ -65,5 +55,26 @@ export class IdleTracker {
     for (const env of [...this.timers.keys()]) {
       this.stop(env);
     }
+  }
+
+  private _scheduleCheck(env: string): void {
+    const last = this.lastActivity.get(env) ?? Date.now();
+    const remaining = this.idleTimeoutMs - (Date.now() - last);
+
+    const timer = setTimeout(
+      () => {
+        const elapsed = Date.now() - (this.lastActivity.get(env) ?? 0);
+        if (elapsed >= this.idleTimeoutMs) {
+          this.stop(env);
+          this.onIdle(env);
+        } else {
+          this._scheduleCheck(env);
+        }
+      },
+      Math.max(remaining, 100),
+    );
+    timer.unref();
+
+    this.timers.set(env, timer);
   }
 }

--- a/src/tunnel/ssh2-provider.ts
+++ b/src/tunnel/ssh2-provider.ts
@@ -32,8 +32,12 @@ interface ActiveTunnel {
 
 export class Ssh2TunnelProvider implements TunnelProvider {
   private readonly active = new Map<string, ActiveTunnel>();
+  private readonly usedPorts = new Set<number>();
   private readonly opts: TunnelLifecycleOptions;
   private readonly idle: IdleTracker;
+
+  /** Set externally after construction to avoid circular references */
+  onReconnect?: (env: string) => void;
 
   constructor(opts: Partial<TunnelLifecycleOptions> = {}) {
     this.opts = { ...DEFAULT_LIFECYCLE, ...opts };
@@ -46,6 +50,14 @@ export class Ssh2TunnelProvider implements TunnelProvider {
     const existing = this.active.get(env);
     if (existing && existing.tunnel.status === "active") {
       return existing.tunnel;
+    }
+
+    // Validate local_port uniqueness across active tunnels
+    if (this.usedPorts.has(config.local_port)) {
+      throw new TunnelError(
+        env,
+        `local_port ${config.local_port} is already in use by another tunnel`,
+      );
     }
 
     return this._openConnection(env, config);
@@ -106,6 +118,7 @@ export class Ssh2TunnelProvider implements TunnelProvider {
               retryCount: 0,
             };
             this.active.set(env, record);
+            this.usedPorts.add(config.local_port);
             this.idle.start(env);
             resolve(tunnel);
           });
@@ -172,7 +185,7 @@ export class Ssh2TunnelProvider implements TunnelProvider {
       await this._openConnection(env, record.config);
       const reconnected = this.active.get(env);
       if (reconnected) reconnected.retryCount = 0;
-      this.opts.onReconnect?.(env);
+      this.onReconnect?.(env);
     } catch {
       // _openConnection already set status; _scheduleReconnect will be called
       // again via the 'close' event on the new conn if it connects and then drops.
@@ -201,6 +214,7 @@ export class Ssh2TunnelProvider implements TunnelProvider {
       });
     });
 
+    this.usedPorts.delete(active.config.local_port);
     this.active.delete(env);
   }
 

--- a/src/utils/env-enum.ts
+++ b/src/utils/env-enum.ts
@@ -1,0 +1,5 @@
+import * as z from "zod/v4";
+
+export function envEnum(names: string[]) {
+  return z.enum(names as [string, ...string[]]);
+}

--- a/src/utils/tool-result.ts
+++ b/src/utils/tool-result.ts
@@ -1,0 +1,9 @@
+import { ToadError } from "./errors.js";
+
+export function toolError(err: unknown) {
+  const message = err instanceof ToadError ? err.message : String(err);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${message}` }],
+    isError: true,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes 8 non-bug findings from the post-Phase 3 code review:

**DRY:**
- Extract `toolError()` utility (`utils/tool-result.ts`) — deduplicate identical error handling across all 5 MCP tools
- Extract `envEnum()` helper (`utils/env-enum.ts`) — remove repeated `z.enum(envNames as [string, ...string[]])` cast in 3 tools

**KISS:**
- Remove unnecessary `as const` casts on `type: "text"` in tool content responses
- Rename config key `tunnels` → `tunnel_options` to avoid confusion with per-env `tunnel` blocks

**Architecture:**
- Conditionally create `Ssh2TunnelProvider` only when at least one env has a tunnel config — no ssh2 overhead for direct-connect setups
- Replace circular `let connectionManager` reference with public `onReconnect` setter on the provider
- Rewrite `IdleTracker` from `setInterval` to `setTimeout` with remaining-time recalculation for precise idle detection (was up to 2× actual timeout)
- Add `timer.unref()` to prevent idle timers from blocking process exit
- Add `local_port` uniqueness validation in `Ssh2TunnelProvider` via `usedPorts` set

**Bonus bug fix:**
- Add try/catch error handling to `tunnel_status` tool (was the only tool without it)

**Ops:**
- Closed Issue #4 (Phase 3 umbrella) — all sub-issues were already done

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 92 tests pass
- [x] Prettier check passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)