### PR TITLE
fix: race condition, reconnect retry, bigint cast, disconnect hang (#30 #31 #34 #35)

### DIFF
--- a/src/router/connection-manager.ts
+++ b/src/router/connection-manager.ts
@@ -6,7 +6,8 @@ import type { TunnelProvider, TunnelConfig } from "../tunnel/types.js";
 const { Pool } = pg;
 
 export class ConnectionManager {
-  private readonly pools: Map<string, pg.Pool> = new Map();
+  // Stores in-flight promises so concurrent getPool() calls share the same connection attempt
+  private readonly pools: Map<string, Promise<pg.Pool>> = new Map();
 
   constructor(
     private readonly config: Config,
@@ -20,48 +21,55 @@ export class ConnectionManager {
     }
 
     if (!this.pools.has(env)) {
-      // Open SSH tunnel lazily if this env requires one
-      let host = envConfig.host;
-      let port = envConfig.port;
-
-      if (envConfig.tunnel && this.tunnelProvider) {
-        const tunnelConfig = this.buildTunnelConfig(env, envConfig);
-        const tunnel = await this.tunnelProvider.connect(env, tunnelConfig);
-        host = "127.0.0.1";
-        port = tunnel.local_port;
-      }
-
-      const pool = new Pool({
-        host,
-        port,
-        database: envConfig.database,
-        user: envConfig.user,
-        password: envConfig.password,
-        max: 5,
-        idleTimeoutMillis: 30_000,
-        connectionTimeoutMillis: 5_000,
-      });
-
-      // Fail fast: verify connection on first pool creation
-      try {
-        const client = await pool.connect();
-        client.release();
-      } catch (err) {
-        await pool.end().catch(() => {});
-        throw new ConnectionError(env, err);
-      }
-
-      this.pools.set(env, pool);
+      this.pools.set(env, this._createPool(env, envConfig));
     }
 
     return this.pools.get(env)!;
   }
 
+  private async _createPool(
+    env: string,
+    envConfig: EnvConfig,
+  ): Promise<pg.Pool> {
+    let host = envConfig.host;
+    let port = envConfig.port;
+
+    if (envConfig.tunnel && this.tunnelProvider) {
+      const tunnelConfig = this.buildTunnelConfig(env, envConfig);
+      const tunnel = await this.tunnelProvider.connect(env, tunnelConfig);
+      host = "127.0.0.1";
+      port = tunnel.local_port;
+    }
+
+    const pool = new Pool({
+      host,
+      port,
+      database: envConfig.database,
+      user: envConfig.user,
+      password: envConfig.password,
+      max: 5,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 5_000,
+    });
+
+    // Fail fast: verify connection on first pool creation
+    try {
+      const client = await pool.connect();
+      client.release();
+    } catch (err) {
+      await pool.end().catch(() => {});
+      this.pools.delete(env); // remove failed promise so next call retries
+      throw new ConnectionError(env, err);
+    }
+
+    return pool;
+  }
+
   /** Called by TunnelProvider.onReconnect to force pool recreation on next getPool() */
   invalidatePool(env: string): void {
-    const pool = this.pools.get(env);
-    if (pool) {
-      void pool.end().catch(() => {});
+    const poolPromise = this.pools.get(env);
+    if (poolPromise) {
+      void poolPromise.then((pool) => pool.end()).catch(() => {});
       this.pools.delete(env);
     }
   }
@@ -77,8 +85,11 @@ export class ConnectionManager {
   }
 
   async shutdown(): Promise<void> {
-    await Promise.all([...this.pools.values()].map((pool) => pool.end()));
+    const poolPromises = [...this.pools.values()];
     this.pools.clear();
+    await Promise.all(
+      poolPromises.map((p) => p.then((pool) => pool.end()).catch(() => {})),
+    );
     await this.tunnelProvider?.disconnectAll();
   }
 

--- a/src/schema/queries.ts
+++ b/src/schema/queries.ts
@@ -20,7 +20,7 @@ export async function queryTables(pool: pg.Pool): Promise<TableOverview[]> {
     SELECT
       n.nspname AS schema,
       c.relname AS table,
-      GREATEST(c.reltuples::bigint, 0) AS estimated_rows
+      GREATEST(c.reltuples::int, 0) AS estimated_rows
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind = 'r'

--- a/src/tunnel/ssh2-provider.ts
+++ b/src/tunnel/ssh2-provider.ts
@@ -25,9 +25,9 @@ interface ActiveTunnel {
   tunnel: Tunnel;
   conn: Client;
   server: net.Server;
+  sockets: Set<net.Socket>;
   config: TunnelConfig;
   intentionalClose: boolean;
-  retryCount: number;
 }
 
 export class Ssh2TunnelProvider implements TunnelProvider {
@@ -79,7 +79,12 @@ export class Ssh2TunnelProvider implements TunnelProvider {
 
       conn
         .on("ready", () => {
+          const sockets = new Set<net.Socket>();
+
           const server = net.createServer((socket) => {
+            sockets.add(socket);
+            socket.on("close", () => sockets.delete(socket));
+
             this.idle.touch(env);
             const active = this.active.get(env);
             if (active) active.tunnel.last_query_at = new Date();
@@ -113,9 +118,9 @@ export class Ssh2TunnelProvider implements TunnelProvider {
               tunnel,
               conn,
               server,
+              sockets,
               config,
               intentionalClose: false,
-              retryCount: 0,
             };
             this.active.set(env, record);
             this.usedPorts.add(config.local_port);
@@ -140,7 +145,9 @@ export class Ssh2TunnelProvider implements TunnelProvider {
         .on("close", () => {
           const record = this.active.get(env);
           if (record && !record.intentionalClose) {
-            void this._scheduleReconnect(env, record);
+            // Pass config and start retry count from 0; retryCount is a local
+            // counter passed through the recursion — not stored on the record
+            void this._scheduleReconnect(env, record.config, 0);
           }
         })
         .connect({
@@ -156,48 +163,52 @@ export class Ssh2TunnelProvider implements TunnelProvider {
     });
   }
 
+  // retryCount is passed explicitly so delete+recreate of the active record
+  // never loses the count (fixes: active.delete before stale read)
   private async _scheduleReconnect(
     env: string,
-    record: ActiveTunnel,
+    config: TunnelConfig,
+    retryCount: number,
   ): Promise<void> {
-    if (record.retryCount >= this.opts.max_retries) {
-      record.tunnel.status = "disconnected";
+    if (retryCount >= this.opts.max_retries) {
+      const record = this.active.get(env);
+      if (record) record.tunnel.status = "disconnected";
       this.idle.stop(env);
       this.opts.onGiveUp?.(env);
       this.active.delete(env);
+      this.usedPorts.delete(config.local_port);
       return;
     }
 
-    record.tunnel.status = "connecting";
-    record.retryCount += 1;
-    const delay = this.opts.retry_delay_ms * Math.pow(2, record.retryCount - 1);
+    const record = this.active.get(env);
+    if (record) record.tunnel.status = "connecting";
 
+    const delay = this.opts.retry_delay_ms * Math.pow(2, retryCount);
     await new Promise<void>((r) => setTimeout(r, delay));
 
-    // Close the old net.Server before reopening
-    await new Promise<void>((resolve) => {
-      record.server.close(() => resolve());
-    });
-
+    // Force-close sockets and server before reopening
+    await this._closeServerForEnv(env);
     this.active.delete(env);
 
     try {
-      await this._openConnection(env, record.config);
-      const reconnected = this.active.get(env);
-      if (reconnected) reconnected.retryCount = 0;
+      await this._openConnection(env, config);
       this.onReconnect?.(env);
     } catch {
-      // _openConnection already set status; _scheduleReconnect will be called
-      // again via the 'close' event on the new conn if it connects and then drops.
-      // If it never connects, reject() is called and we give up here.
-      const stale = this.active.get(env);
-      if (stale && stale.retryCount < this.opts.max_retries) {
-        void this._scheduleReconnect(env, stale);
-      } else {
-        this.opts.onGiveUp?.(env);
-        this.active.delete(env);
-      }
+      void this._scheduleReconnect(env, config, retryCount + 1);
     }
+  }
+
+  private async _closeServerForEnv(env: string): Promise<void> {
+    const record = this.active.get(env);
+    if (!record) return;
+    // Destroy all open sockets so server.close() resolves immediately
+    for (const socket of record.sockets) {
+      socket.destroy();
+    }
+    record.sockets.clear();
+    await new Promise<void>((resolve) => {
+      record.server.close(() => resolve());
+    });
   }
 
   async disconnect(env: string): Promise<void> {
@@ -206,6 +217,12 @@ export class Ssh2TunnelProvider implements TunnelProvider {
 
     active.intentionalClose = true;
     this.idle.stop(env);
+
+    // Destroy sockets first so server.close() resolves without waiting for idle timeout
+    for (const socket of active.sockets) {
+      socket.destroy();
+    }
+    active.sockets.clear();
 
     await new Promise<void>((resolve) => {
       active.server.close(() => {


### PR DESCRIPTION
## Bugs fixed

**#30 — Race condition in `getPool()`** (High)
- `Map<string, pg.Pool>` → `Map<string, Promise<pg.Pool>>`
- Concurrent callers now share the same in-flight promise
- Failed promises are removed from the map so the next call retries cleanly

**#31 — Reconnect loses retry count** (High)
- `_scheduleReconnect(env, record)` → `_scheduleReconnect(env, config, retryCount)`
- `retryCount` is passed explicitly through recursion — no longer read from `this.active` after `delete`
- Previous behavior: always read `undefined` → gave up after the first failure regardless of `max_retries`

**#34 — `estimated_rows` bigint → string** (Low)
- `::bigint` → `::int` in `queryTables()` SQL
- `pg` driver returns `bigint` columns as JavaScript strings; `int4` (2.1B) is sufficient for row count estimates

**#35 — `disconnect()` hangs on active connections** (Medium)
- Track open sockets in `Set<net.Socket>` per server
- On `disconnect()`, destroy all sockets before calling `server.close()`
- Previously waited up to `idleTimeoutMillis: 30s` per tunnel for pg pool connections to time out

## Also closed
- #32 — already fixed in review PR (tunnel_status has try/catch)
- #33 — already fixed in review PR (IdleTracker calls `.unref()`)

## Test plan
- [x] 92 tests passing, no regressions
- [x] TypeScript strict, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)