### PR TITLE
feat(phase-4a): PostgreSQL read-only roles — primary defence

### DIFF
--- a/config/toad-tunnel.yaml
+++ b/config/toad-tunnel.yaml
@@ -14,7 +14,7 @@ environments:
     host: localhost
     port: 5432
     database: sandbox_stage
-    user: toad
+    user: toad_reader
     password: toad_secret
     permissions: read-only
     approval: auto
@@ -23,7 +23,7 @@ environments:
     host: localhost
     port: 5432
     database: sandbox_prod
-    user: toad
+    user: toad_reader
     password: toad_secret
     permissions: read-only
     approval: hitl

--- a/sandbox/init/00-create-roles.sql
+++ b/sandbox/init/00-create-roles.sql
@@ -1,0 +1,5 @@
+-- Read-only role for stage/prod environments.
+-- default_transaction_read_only = ON means even if the router blocklist
+-- is bypassed, the database itself will reject any mutation attempt.
+CREATE ROLE toad_reader WITH LOGIN PASSWORD 'toad_secret';
+ALTER ROLE toad_reader SET default_transaction_read_only = ON;

--- a/sandbox/init/01-create-databases.sql
+++ b/sandbox/init/01-create-databases.sql
@@ -3,3 +3,7 @@ CREATE DATABASE sandbox_dev;
 CREATE DATABASE sandbox_stage;
 CREATE DATABASE sandbox_prod;
 CREATE DATABASE sandbox_dev2;
+
+-- Grant toad_reader connect access to read-only environments
+GRANT CONNECT ON DATABASE sandbox_stage TO toad_reader;
+GRANT CONNECT ON DATABASE sandbox_prod TO toad_reader;

--- a/sandbox/init/02-create-schema.sh
+++ b/sandbox/init/02-create-schema.sh
@@ -43,3 +43,14 @@ for DB in sandbox_dev sandbox_stage sandbox_prod sandbox_dev2; do
 EOSQL
   echo "Schema created for $DB"
 done
+
+# Grant toad_reader SELECT on stage/prod tables
+# This runs after schema creation so all tables exist
+for DB in sandbox_stage sandbox_prod; do
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB" <<-EOSQL
+    GRANT USAGE ON SCHEMA public TO toad_reader;
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO toad_reader;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO toad_reader;
+EOSQL
+  echo "Read-only grants applied for $DB"
+done

--- a/src/router/pg-roles.test.ts
+++ b/src/router/pg-roles.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for PostgreSQL read-only role enforcement (Phase 4 primary defence).
+ * toad_reader role has default_transaction_read_only = ON at the DB level.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import pg from "pg";
+
+const { Pool } = pg;
+
+const readerPool = new Pool({
+  host: "localhost",
+  port: 5432,
+  database: "sandbox_stage",
+  user: "toad_reader",
+  password: "toad_secret",
+});
+
+const writerPool = new Pool({
+  host: "localhost",
+  port: 5432,
+  database: "sandbox_dev",
+  user: "toad",
+  password: "toad_secret",
+});
+
+afterAll(async () => {
+  await readerPool.end();
+  await writerPool.end();
+});
+
+describe("PostgreSQL read-only role enforcement", () => {
+  it("toad_reader can SELECT from stage", async () => {
+    const result = await readerPool.query("SELECT COUNT(*) AS n FROM products");
+    expect(Number(result.rows[0].n)).toBeGreaterThan(0);
+  });
+
+  it("toad_reader cannot INSERT — PG rejects at the wire level", async () => {
+    await expect(
+      readerPool.query(
+        "INSERT INTO products(code, title, price, currency, source) VALUES('TEST-RO', 'test', 1.00, 'USD', 'test')",
+      ),
+    ).rejects.toThrow(/read.only/i);
+  });
+
+  it("toad_reader cannot UPDATE — PG rejects at the wire level", async () => {
+    await expect(
+      readerPool.query("UPDATE products SET status = 'inactive' WHERE id = 1"),
+    ).rejects.toThrow(/read.only/i);
+  });
+
+  it("toad_reader cannot DELETE — PG rejects at the wire level", async () => {
+    await expect(
+      readerPool.query("DELETE FROM products WHERE id = 999999"),
+    ).rejects.toThrow(/read.only/i);
+  });
+
+  it("toad_reader cannot DROP TABLE — PG rejects at the wire level", async () => {
+    await expect(readerPool.query("DROP TABLE products")).rejects.toThrow(
+      /read.only/i,
+    );
+  });
+
+  it("toad (read-write) can INSERT and DELETE in dev", async () => {
+    await writerPool.query(
+      "INSERT INTO products(code, title, price, currency, source) VALUES('TEST-RW', 'rw test', 1.00, 'USD', 'test')",
+    );
+    const result = await writerPool.query(
+      "SELECT id FROM products WHERE code = 'TEST-RW'",
+    );
+    expect(result.rows.length).toBe(1);
+    await writerPool.query("DELETE FROM products WHERE code = 'TEST-RW'");
+  });
+});


### PR DESCRIPTION
## Summary

Primary defence layer: even if the router blocklist is bypassed, the database itself rejects mutations.

### Changes

**`sandbox/init/00-create-roles.sql`** (new)
- Creates `toad_reader` role with `default_transaction_read_only = ON`
- Runs before database creation (alphabetical order ensures correct init sequence)

**`sandbox/init/01-create-databases.sql`**
- `GRANT CONNECT ON DATABASE sandbox_stage/prod TO toad_reader`

**`sandbox/init/02-create-schema.sh`**
- After schema creation: `GRANT USAGE + SELECT ON ALL TABLES` to `toad_reader` for stage/prod
- `ALTER DEFAULT PRIVILEGES` so future tables are also covered

**`config/toad-tunnel.yaml`**
- `stage` and `prod` now use `user: toad_reader` (read-only PG role)
- `dev` and `dev2` keep `user: toad` (read-write)

### Security model (local, gitignored)
Documented in `.planning/security-model.md`:
- Three defense layers: PG role → router blocklist → HITL
- Threat vectors and mitigations
- Confused Deputy: `env` from Zod enum is the only source of truth (no dynamic resolution from SQL)
- Non-goals: network security, prompt injection, transport auth

## Test plan

- [x] `toad_reader` INSERT → `cannot execute INSERT in a read-only transaction`
- [x] `toad_reader` UPDATE → rejected
- [x] `toad_reader` DELETE → rejected
- [x] `toad_reader` DROP TABLE → rejected
- [x] `toad_reader` SELECT → succeeds
- [x] `toad` INSERT/DELETE in dev → succeeds
- [x] 98 tests total, all green

> **Note:** requires `npm run sandbox:reset` to rebuild the sandbox with new init scripts.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)