### PR TITLE
feat(phase-4b): QueryValidator — keyword blocklist + row budget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerListNodes } from "./tools/list-nodes.js";
 import { registerGetOverview } from "./tools/get-overview.js";
 import { registerDescribeColumns } from "./tools/describe-columns.js";
 import { registerTunnelStatus } from "./tools/tunnel-status.js";
+import { QueryValidator } from "./safety/query-validator.js";
 
 const CONFIG_PATH = process.env["TOAD_CONFIG"] ?? "config/toad-tunnel.yaml";
 
@@ -35,7 +36,8 @@ const server = new McpServer({
 registerListNodes(server, connectionManager);
 registerGetOverview(server, connectionManager, schemaCache);
 registerDescribeColumns(server, connectionManager, schemaCache);
-registerExecuteQuery(server, connectionManager);
+const validator = new QueryValidator(config.safety);
+registerExecuteQuery(server, connectionManager, validator);
 if (tunnelProvider) {
   registerTunnelStatus(server, connectionManager, tunnelProvider);
 }

--- a/src/router/query-executor.test.ts
+++ b/src/router/query-executor.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { ConnectionManager } from "./connection-manager.js";
+import { executeQuery, BlockedQueryError } from "./query-executor.js";
+import { QueryValidator } from "../safety/query-validator.js";
+import { type Config } from "../config/schema.js";
+
+const config: Config = {
+  project: "test",
+  environments: {
+    dev: {
+      host: "localhost",
+      port: 5432,
+      database: "sandbox_dev",
+      user: "toad",
+      password: "toad_secret",
+      permissions: "read-write",
+      approval: "auto",
+    },
+    stage: {
+      host: "localhost",
+      port: 5432,
+      database: "sandbox_stage",
+      user: "toad_reader",
+      password: "toad_secret",
+      permissions: "read-only",
+      approval: "auto",
+    },
+  },
+};
+
+const validator = new QueryValidator({ max_rows: 3 });
+
+describe("executeQuery with QueryValidator", () => {
+  const manager = new ConnectionManager(config);
+
+  afterAll(async () => {
+    await manager.shutdown();
+  });
+
+  it("passes SELECT through to read-only env", async () => {
+    const result = await executeQuery(
+      manager,
+      "stage",
+      "SELECT 1 AS n",
+      validator,
+    );
+    expect(result.rows[0]).toMatchObject({ n: 1 });
+    expect(result.truncated).toBe(false);
+  });
+
+  it("blocks DELETE on read-only env before reaching DB", async () => {
+    await expect(
+      executeQuery(
+        manager,
+        "stage",
+        "DELETE FROM products WHERE id = 999",
+        validator,
+      ),
+    ).rejects.toThrow(BlockedQueryError);
+  });
+
+  it("allows DELETE on read-write env (blocklist skipped)", async () => {
+    // This will fail at PG level because id 999999999 doesn't exist, but
+    // it must NOT throw BlockedQueryError — validator allows read-write envs
+    const result = await executeQuery(
+      manager,
+      "dev",
+      "DELETE FROM products WHERE id = 999999999",
+      validator,
+    );
+    expect(result.rowCount).toBe(0);
+  });
+
+  it("blocks keyword inside CTE on read-only env", async () => {
+    await expect(
+      executeQuery(
+        manager,
+        "stage",
+        "WITH x AS (DELETE FROM products RETURNING *) SELECT * FROM x",
+        validator,
+      ),
+    ).rejects.toThrow(BlockedQueryError);
+  });
+
+  it("truncates results when row count exceeds max_rows", async () => {
+    // sandbox_stage has 800+ products, budget is 3
+    const result = await executeQuery(
+      manager,
+      "stage",
+      "SELECT id FROM products",
+      validator,
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.rows.length).toBe(3);
+    expect(result.rowCount).toBe(3);
+  });
+
+  it("does not truncate when result is within budget", async () => {
+    const result = await executeQuery(
+      manager,
+      "stage",
+      "SELECT 1 AS n UNION SELECT 2",
+      validator,
+    );
+    expect(result.truncated).toBe(false);
+    expect(result.rows.length).toBe(2);
+  });
+
+  it("no validator — no blocklist, no row budget", async () => {
+    const result = await executeQuery(manager, "stage", "SELECT 1 AS n");
+    expect(result.truncated).toBe(false);
+    expect(result.rows[0]).toMatchObject({ n: 1 });
+  });
+});

--- a/src/router/query-executor.ts
+++ b/src/router/query-executor.ts
@@ -1,19 +1,52 @@
 import { type ConnectionManager } from "./connection-manager.js";
+import { type QueryValidator } from "../safety/query-validator.js";
+import { ToadError } from "../utils/errors.js";
+
+export class BlockedQueryError extends ToadError {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "BlockedQueryError";
+  }
+}
 
 export interface QueryResult {
   rows: Record<string, unknown>[];
   rowCount: number;
+  truncated: boolean;
+  totalFetched: number;
 }
 
 export async function executeQuery(
   connectionManager: ConnectionManager,
   env: string,
   sql: string,
+  validator?: QueryValidator,
 ): Promise<QueryResult> {
+  const envConfig = connectionManager.getEnvConfig(env);
+
+  // Layer 2: keyword blocklist (fast-fail before touching the DB)
+  if (validator) {
+    const check = validator.validate(sql, envConfig.permissions);
+    if (!check.ok) {
+      throw new BlockedQueryError(check.reason);
+    }
+  }
+
   const pool = await connectionManager.getPool(env);
-  const result = await pool.query(sql);
+
+  // Apply row budget — only for SELECT statements
+  const budgeted = validator ? validator.wrapWithBudget(sql) : null;
+  const querySql = budgeted ? budgeted.sql : sql;
+  const fetchLimit = budgeted ? budgeted.fetchLimit : Infinity;
+
+  const result = await pool.query(querySql);
+  const rows = result.rows;
+  const truncated = isFinite(fetchLimit) && rows.length >= fetchLimit;
+
   return {
-    rows: result.rows,
-    rowCount: result.rowCount ?? result.rows.length,
+    rows: truncated ? rows.slice(0, fetchLimit - 1) : rows,
+    rowCount: truncated ? fetchLimit - 1 : (result.rowCount ?? rows.length),
+    truncated,
+    totalFetched: rows.length,
   };
 }

--- a/src/safety/query-validator.test.ts
+++ b/src/safety/query-validator.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { QueryValidator, DEFAULT_BLOCKED_KEYWORDS } from "./query-validator.js";
+
+describe("QueryValidator — keyword blocklist", () => {
+  const validator = new QueryValidator({
+    blocked_keywords: DEFAULT_BLOCKED_KEYWORDS,
+    max_rows: 100,
+  });
+
+  it("passes a clean SELECT for read-only env", () => {
+    expect(validator.validate("SELECT * FROM products", "read-only")).toEqual({
+      ok: true,
+    });
+  });
+
+  it("blocks DELETE on read-only env", () => {
+    const result = validator.validate(
+      "DELETE FROM products WHERE id = 1",
+      "read-only",
+    );
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; reason: string }).reason).toMatch(/DELETE/);
+  });
+
+  it("blocks DROP TABLE", () => {
+    const result = validator.validate("DROP TABLE products", "read-only");
+    expect(result.ok).toBe(false);
+  });
+
+  it("blocks INSERT", () => {
+    const result = validator.validate(
+      "INSERT INTO products VALUES(1)",
+      "read-only",
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("blocks UPDATE", () => {
+    const result = validator.validate(
+      "UPDATE products SET status='x'",
+      "read-only",
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("blocks TRUNCATE", () => {
+    expect(validator.validate("TRUNCATE products", "read-only").ok).toBe(false);
+  });
+
+  it("blocks keyword inside CTE — WITH x AS (DELETE ...)", () => {
+    const result = validator.validate(
+      "WITH x AS (DELETE FROM products RETURNING *) SELECT * FROM x",
+      "read-only",
+    );
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; reason: string }).reason).toMatch(/DELETE/);
+  });
+
+  it("blocks keyword inside block comment stripped — not tricked by /* DELETE */", () => {
+    // Comment is stripped → keyword is gone → SELECT passes
+    const result = validator.validate(
+      "/* DELETE FROM products */ SELECT 1",
+      "read-only",
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("blocks keyword after line comment stripped", () => {
+    // Comment is stripped → keyword is gone → passes
+    const result = validator.validate(
+      "-- DELETE FROM products\nSELECT 1",
+      "read-only",
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("does NOT block column name that contains a keyword as substring", () => {
+    // CREATED_AT contains CREATE but should not match \\bCREATE\\b
+    const result = validator.validate(
+      "SELECT created_at FROM products",
+      "read-only",
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("skips blocklist for read-write env", () => {
+    expect(
+      validator.validate("DELETE FROM products WHERE id = 1", "read-write"),
+    ).toEqual({ ok: true });
+  });
+
+  it("empty blocklist always passes", () => {
+    const v = new QueryValidator({ blocked_keywords: [], max_rows: 100 });
+    expect(v.validate("DROP TABLE products", "read-only")).toEqual({
+      ok: true,
+    });
+  });
+});
+
+describe("QueryValidator — row budget", () => {
+  const validator = new QueryValidator({ max_rows: 5 });
+
+  it("wraps SELECT with LIMIT max+1", () => {
+    const result = validator.wrapWithBudget("SELECT * FROM products");
+    expect(result).not.toBeNull();
+    expect(result!.fetchLimit).toBe(6);
+    expect(result!.sql).toContain("LIMIT 6");
+    expect(result!.sql).toContain("_toad_budget");
+  });
+
+  it("fetchLimit is always maxRows + 1", () => {
+    const v = new QueryValidator({ max_rows: 100 });
+    expect(v.wrapWithBudget("SELECT 1")!.fetchLimit).toBe(101);
+  });
+
+  it("returns null for non-SELECT statements", () => {
+    expect(validator.wrapWithBudget("DELETE FROM products")).toBeNull();
+    expect(
+      validator.wrapWithBudget("INSERT INTO products VALUES(1)"),
+    ).toBeNull();
+    expect(validator.wrapWithBudget("UPDATE products SET x=1")).toBeNull();
+  });
+});

--- a/src/safety/query-validator.ts
+++ b/src/safety/query-validator.ts
@@ -1,0 +1,88 @@
+export type ValidationResult = { ok: true } | { ok: false; reason: string };
+
+export interface SafetyOptions {
+  blocked_keywords: string[];
+  max_rows: number;
+}
+
+export const DEFAULT_BLOCKED_KEYWORDS = [
+  "DROP",
+  "DELETE",
+  "ALTER",
+  "TRUNCATE",
+  "GRANT",
+  "REVOKE",
+  "CREATE",
+  "UPDATE",
+  "INSERT",
+];
+
+export class QueryValidator {
+  private readonly blockedUpper: string[];
+  readonly maxRows: number;
+
+  constructor(opts: Partial<SafetyOptions> = {}) {
+    this.blockedUpper = (opts.blocked_keywords ?? DEFAULT_BLOCKED_KEYWORDS).map(
+      (k) => k.toUpperCase(),
+    );
+    this.maxRows = opts.max_rows ?? 100;
+  }
+
+  /**
+   * Validate SQL against the keyword blocklist.
+   * Blocklist is only applied for read-only environments.
+   * Returns { ok: false, reason } if a blocked keyword is found.
+   */
+  validate(
+    sql: string,
+    permissions: "read-only" | "read-write",
+  ): ValidationResult {
+    if (permissions === "read-write") return { ok: true };
+    if (this.blockedUpper.length === 0) return { ok: true };
+
+    const normalized = this._normalize(sql);
+
+    for (const keyword of this.blockedUpper) {
+      // Match keyword as a whole word so e.g. "CREATED_AT" doesn't match "CREATE"
+      const pattern = new RegExp(`\\b${keyword}\\b`);
+      if (pattern.test(normalized)) {
+        return {
+          ok: false,
+          reason:
+            `Blocked keyword "${keyword}" detected. ` +
+            `This environment is read-only. ` +
+            `Note: the blocklist is a fast-fail layer — ` +
+            `the primary defence is the PostgreSQL read-only role.`,
+        };
+      }
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * Wrap SQL in a subquery to enforce the row budget.
+   * Only applied to SELECT statements — mutations return row counts, not result sets.
+   * Fetch max+1 rows so we can detect truncation without a separate COUNT query.
+   */
+  wrapWithBudget(sql: string): { sql: string; fetchLimit: number } | null {
+    const normalized = this._normalize(sql);
+    if (!normalized.startsWith("SELECT")) return null;
+
+    const fetchLimit = this.maxRows + 1;
+    return {
+      sql: `SELECT * FROM (${sql}) AS _toad_budget LIMIT ${fetchLimit}`,
+      fetchLimit,
+    };
+  }
+
+  /** Normalize SQL for keyword matching: strip comments, uppercase, collapse whitespace */
+  private _normalize(sql: string): string {
+    return sql
+      .replace(/--[^\n]*/g, " ") // strip line comments
+      .replace(/\/\*[\s\S]*?\*\//g, " ") // strip block comments
+      .toUpperCase()
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+}

--- a/src/tools/execute-query.ts
+++ b/src/tools/execute-query.ts
@@ -1,6 +1,7 @@
 import * as z from "zod/v4";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type ConnectionManager } from "../router/connection-manager.js";
+import { type QueryValidator } from "../safety/query-validator.js";
 import { executeQuery } from "../router/query-executor.js";
 import { toolError } from "../utils/tool-result.js";
 import { envEnum } from "../utils/env-enum.js";
@@ -8,6 +9,7 @@ import { envEnum } from "../utils/env-enum.js";
 export function registerExecuteQuery(
   server: McpServer,
   connectionManager: ConnectionManager,
+  validator?: QueryValidator,
 ): void {
   const envNames = connectionManager.getEnvNames();
 
@@ -25,13 +27,27 @@ export function registerExecuteQuery(
     },
     async ({ env, sql }) => {
       try {
-        const result = await executeQuery(connectionManager, env, sql);
-        const text =
-          result.rowCount === 0
-            ? "(no rows)"
-            : result.rows.map((row) => JSON.stringify(row)).join("\n");
+        const result = await executeQuery(
+          connectionManager,
+          env,
+          sql,
+          validator,
+        );
 
-        return { content: [{ type: "text", text }] };
+        if (result.rowCount === 0 && !result.truncated) {
+          return { content: [{ type: "text", text: "(no rows)" }] };
+        }
+
+        const lines = result.rows.map((row) => JSON.stringify(row));
+
+        if (result.truncated) {
+          lines.push(
+            `\n[${result.rowCount}+ rows — showing first ${result.rowCount}. ` +
+              `Add LIMIT or WHERE to narrow results.]`,
+          );
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
       } catch (err) {
         return toolError(err);
       }


### PR DESCRIPTION
## Summary

**Layer 2** of the safety stack: router-level fast-fail before queries reach the database.

### `QueryValidator` (`src/safety/`)

**Keyword blocklist**
- SQL normalization: strip `--` line comments + `/* */` block comments → uppercase → collapse whitespace
- Whole-word matching: `CREATED_AT` does not trigger `CREATE`
- Catches keywords in CTEs: `WITH x AS (DELETE ...) SELECT *` → blocked
- Applied only for `permissions: read-only` envs; read-write envs skip entirely
- Comments containing blocked keywords are stripped first — not fooled by `/* DELETE */`

**Row budget**
- `wrapWithBudget()` wraps SELECT in `SELECT * FROM (...) AS _toad_budget LIMIT max+1`
- Returns `null` for non-SELECT (mutations, DDL) — budget wrapper would be invalid SQL
- Fetches `max+1` rows to detect truncation without a separate `COUNT(*)` query
- Truncation summary appended to response: `[100+ rows — showing first 100. Add LIMIT or WHERE to narrow results.]`

### Integration
- `executeQuery()` accepts optional `QueryValidator`; throws `BlockedQueryError` on match
- `registerExecuteQuery()` accepts validator and formats truncated responses
- `index.ts`: `QueryValidator` created from `config.safety`

## Test plan

- [x] 14 unit tests: blocklist (passes, blocks, CTE, comment stripping, column names), row budget (SELECT wraps, non-SELECT returns null)
- [x] 7 integration tests against sandbox: blocked keyword, CTE block, read-write bypass, truncation, no-validator passthrough
- [x] 120 tests total, all green
- [x] TypeScript strict, no errors

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)