### PR TITLE
feat(safety): HITL elicitation for approval=hitl environments (#23)

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -27,6 +27,7 @@ const EnvConfigSchema = z.object({
 const SafetyConfigSchema = z.object({
   blocked_keywords: z.array(z.string()).default([]),
   max_rows: z.number().default(100),
+  hitl_timeout_ms: z.number().default(60_000),
 });
 
 export const ConfigSchema = z.object({

--- a/src/safety/query-validator.ts
+++ b/src/safety/query-validator.ts
@@ -3,6 +3,7 @@ export type ValidationResult = { ok: true } | { ok: false; reason: string };
 export interface SafetyOptions {
   blocked_keywords: string[];
   max_rows: number;
+  hitl_timeout_ms: number;
 }
 
 export const DEFAULT_BLOCKED_KEYWORDS = [
@@ -20,12 +21,14 @@ export const DEFAULT_BLOCKED_KEYWORDS = [
 export class QueryValidator {
   private readonly blockedUpper: string[];
   readonly maxRows: number;
+  readonly hitlTimeoutMs: number;
 
   constructor(opts: Partial<SafetyOptions> = {}) {
     this.blockedUpper = (opts.blocked_keywords ?? DEFAULT_BLOCKED_KEYWORDS).map(
       (k) => k.toUpperCase(),
     );
     this.maxRows = opts.max_rows ?? 100;
+    this.hitlTimeoutMs = opts.hitl_timeout_ms ?? 60_000;
   }
 
   /**

--- a/src/tools/execute-query.test.ts
+++ b/src/tools/execute-query.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerExecuteQuery } from "./execute-query.js";
+import { QueryValidator } from "../safety/query-validator.js";
+
+// ---------------------------------------------------------------------------
+// Minimal stubs
+// ---------------------------------------------------------------------------
+
+function makeValidator(
+  opts: { hitl_timeout_ms?: number } = {},
+): QueryValidator {
+  return new QueryValidator({
+    blocked_keywords: [],
+    max_rows: 100,
+    hitl_timeout_ms: opts.hitl_timeout_ms ?? 5_000,
+  });
+}
+
+function makeEnvConfig(
+  approval: "auto" | "hitl",
+  permissions: "read-only" | "read-write" = "read-write",
+) {
+  return {
+    host: "localhost",
+    port: 5432,
+    database: "db",
+    user: "user",
+    password: "pass",
+    permissions,
+    approval,
+  };
+}
+
+function makePool(rows: Record<string, unknown>[] = []) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows, rowCount: rows.length }),
+  };
+}
+
+function makeConnectionManager(
+  approval: "auto" | "hitl" = "auto",
+  rows: Record<string, unknown>[] = [],
+) {
+  const pool = makePool(rows);
+  return {
+    getEnvNames: () => ["test"],
+    getEnvConfig: vi.fn().mockReturnValue(makeEnvConfig(approval)),
+    getPool: vi.fn().mockResolvedValue(pool),
+  };
+}
+
+type ToolHandler = (args: { env: string; sql: string }) => Promise<unknown>;
+
+/** Capture the registered handler from server.registerTool */
+function captureHandler(server: ReturnType<typeof makeMcpServer>): ToolHandler {
+  const calls = (server.registerTool as ReturnType<typeof vi.fn>).mock.calls;
+  if (calls.length === 0) throw new Error("registerTool not called");
+  return calls[0][2] as ToolHandler;
+}
+
+function makeMcpServer(elicitResult?: {
+  action: "accept" | "decline" | "cancel";
+  content?: Record<string, unknown>;
+}) {
+  return {
+    registerTool: vi.fn(),
+    server: {
+      elicitInput: vi
+        .fn()
+        .mockResolvedValue(
+          elicitResult ?? { action: "accept", content: { confirmed: true } },
+        ),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — auto-approval (no elicitation)
+// ---------------------------------------------------------------------------
+
+describe("execute-query tool — auto approval", () => {
+  it("returns rows when query succeeds", async () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    const manager = makeConnectionManager("auto", rows);
+    const server = makeMcpServer();
+    const validator = makeValidator();
+
+    registerExecuteQuery(server as never, manager as never, validator);
+    const handler = captureHandler(server);
+
+    const result = await handler({ env: "test", sql: "SELECT * FROM t" });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: '{"id":1}\n{"id":2}' }],
+    });
+    expect(server.server.elicitInput).not.toHaveBeenCalled();
+  });
+
+  it('returns "(no rows)" for empty result', async () => {
+    const manager = makeConnectionManager("auto", []);
+    const server = makeMcpServer();
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server);
+
+    const result = await handler({ env: "test", sql: "SELECT 1" });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "(no rows)" }],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — HITL approval
+// ---------------------------------------------------------------------------
+
+describe("execute-query tool — HITL approval", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("proceeds when user accepts and checks confirmed", async () => {
+    const rows = [{ id: 42 }];
+    const manager = makeConnectionManager("hitl", rows);
+    const server = makeMcpServer({
+      action: "accept",
+      content: { confirmed: true },
+    });
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server);
+
+    const result = await handler({ env: "test", sql: "SELECT 42" });
+    expect(server.server.elicitInput).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: '{"id":42}' }],
+    });
+  });
+
+  it("rejects when user declines", async () => {
+    const manager = makeConnectionManager("hitl");
+    const server = makeMcpServer({ action: "decline" });
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server);
+
+    const result = await handler({ env: "test", sql: "SELECT 1" });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("declined") }],
+    });
+    expect(manager.getPool).not.toHaveBeenCalled();
+  });
+
+  it("rejects when user cancels", async () => {
+    const manager = makeConnectionManager("hitl");
+    const server = makeMcpServer({ action: "cancel" });
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server);
+
+    const result = await handler({ env: "test", sql: "SELECT 1" });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("cancelled") }],
+    });
+    expect(manager.getPool).not.toHaveBeenCalled();
+  });
+
+  it("rejects when accepted but confirmed is false", async () => {
+    const manager = makeConnectionManager("hitl");
+    const server = makeMcpServer({
+      action: "accept",
+      content: { confirmed: false },
+    });
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server);
+
+    const result = await handler({ env: "test", sql: "SELECT 1" });
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("not checked") }],
+    });
+    expect(manager.getPool).not.toHaveBeenCalled();
+  });
+
+  it("rejects on timeout", async () => {
+    const manager = makeConnectionManager("hitl");
+    // elicitInput never resolves
+    const server = {
+      registerTool: vi.fn(),
+      server: {
+        elicitInput: vi.fn().mockImplementation(
+          () => new Promise(() => {}), // hang forever
+        ),
+      },
+    };
+
+    const validator = makeValidator({ hitl_timeout_ms: 1_000 });
+    registerExecuteQuery(server as never, manager as never, validator);
+    const handler = captureHandler(server as ReturnType<typeof makeMcpServer>);
+
+    const resultPromise = handler({ env: "test", sql: "SELECT 1" });
+    // Advance fake timers to trigger the timeout
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("timed out") }],
+    });
+    expect(manager.getPool).not.toHaveBeenCalled();
+  });
+
+  it("rejects gracefully when elicitInput throws (client unsupported)", async () => {
+    const manager = makeConnectionManager("hitl");
+    const server = {
+      registerTool: vi.fn(),
+      server: {
+        elicitInput: vi.fn().mockRejectedValue(new Error("Method not found")),
+      },
+    };
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server as ReturnType<typeof makeMcpServer>);
+
+    const result = await handler({ env: "test", sql: "SELECT 1" });
+    expect(result).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining("elicitation failed"),
+        },
+      ],
+    });
+    expect(manager.getPool).not.toHaveBeenCalled();
+  });
+
+  it("includes SQL preview in the elicitation message", async () => {
+    const manager = makeConnectionManager("hitl", []);
+    const server = makeMcpServer({
+      action: "accept",
+      content: { confirmed: true },
+    });
+
+    registerExecuteQuery(server as never, manager as never, makeValidator());
+    const handler = captureHandler(server);
+
+    await handler({ env: "test", sql: "SELECT * FROM products" });
+
+    const call = (server.server.elicitInput as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(call.message).toContain("SELECT * FROM products");
+  });
+});

--- a/src/tools/execute-query.ts
+++ b/src/tools/execute-query.ts
@@ -6,6 +6,15 @@ import { executeQuery } from "../router/query-executor.js";
 import { toolError } from "../utils/tool-result.js";
 import { envEnum } from "../utils/env-enum.js";
 
+const SQL_PREVIEW_MAX = 500;
+
+/** Truncate SQL for display in the elicitation prompt */
+function sqlPreview(sql: string): string {
+  const trimmed = sql.trim();
+  if (trimmed.length <= SQL_PREVIEW_MAX) return trimmed;
+  return trimmed.slice(0, SQL_PREVIEW_MAX) + "\n… (truncated)";
+}
+
 export function registerExecuteQuery(
   server: McpServer,
   connectionManager: ConnectionManager,
@@ -27,6 +36,74 @@ export function registerExecuteQuery(
     },
     async ({ env, sql }) => {
       try {
+        const envConfig = connectionManager.getEnvConfig(env);
+
+        // Layer 3: HITL confirmation for environments that require it
+        if (envConfig.approval === "hitl") {
+          const timeoutMs = validator?.hitlTimeoutMs ?? 60_000;
+
+          let elicitResult: {
+            action: string;
+            content?: Record<string, unknown>;
+          };
+          try {
+            elicitResult = await Promise.race([
+              server.server.elicitInput({
+                message:
+                  `Environment **${env}** requires your approval before executing.\n\n` +
+                  `\`\`\`sql\n${sqlPreview(sql)}\n\`\`\`\n\n` +
+                  `Approve to proceed.`,
+                requestedSchema: {
+                  type: "object" as const,
+                  properties: {
+                    confirmed: {
+                      type: "boolean",
+                      title: "Approve query",
+                      description: "Check to approve execution",
+                      default: false,
+                    },
+                  },
+                  required: ["confirmed"],
+                },
+              }),
+              new Promise<never>((_, reject) =>
+                setTimeout(
+                  () => reject(new Error("HITL_TIMEOUT")),
+                  timeoutMs,
+                ).unref(),
+              ),
+            ]);
+          } catch (err) {
+            const msg =
+              err instanceof Error && err.message === "HITL_TIMEOUT"
+                ? `Query rejected: approval timed out after ${timeoutMs / 1000}s.`
+                : `Query rejected: elicitation failed (${err instanceof Error ? err.message : String(err)}).`;
+            return { content: [{ type: "text", text: msg }] };
+          }
+
+          if (elicitResult.action !== "accept") {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Query rejected: user ${elicitResult.action === "decline" ? "declined" : "cancelled"} approval.`,
+                },
+              ],
+            };
+          }
+
+          if (!elicitResult.content?.["confirmed"]) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Query rejected: approval checkbox was not checked.",
+                },
+              ],
+            };
+          }
+        }
+
         const result = await executeQuery(
           connectionManager,
           env,


### PR DESCRIPTION
## Summary
- Adds human-in-the-loop confirmation via `server.server.elicitInput()` (MCP form elicitation) for environments configured with `approval: hitl`
- User must accept the elicitation prompt AND check a "Approve query" checkbox to proceed; decline / cancel / unchecked / timeout each produce a safe rejection response without touching the DB
- `hitl_timeout_ms` added to `SafetyConfigSchema` (default 60 s) and exposed as `QueryValidator.hitlTimeoutMs`; timeout races `elicitInput` via `Promise.race` with `.unref()` so it doesn't block process exit
- Elicitation failures (client that doesn't support the capability) are caught and returned as safe rejection messages

## Changes
| File | Change |
|------|--------|
| `src/config/schema.ts` | Add `hitl_timeout_ms` to `SafetyConfigSchema` |
| `src/safety/query-validator.ts` | Add `hitl_timeout_ms` to `SafetyOptions`, expose `hitlTimeoutMs` |
| `src/tools/execute-query.ts` | Accept `McpServer`, HITL gate before `executeQuery`, SQL preview helper |
| `src/tools/execute-query.test.ts` | 9 unit tests covering all HITL outcomes |

## Test plan
- [x] `npx vitest run` — 129/129 pass
- [x] `npx tsc --noEmit` — no errors
- [ ] Manual smoke test: configure env with `approval: hitl`, call tool, verify elicitation prompt appears in MCP client

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)