### PR TITLE
fix: blocklist before HITL + elicitation hardening

### DIFF
--- a/src/safety/query-validator.ts
+++ b/src/safety/query-validator.ts
@@ -79,11 +79,18 @@ export class QueryValidator {
     };
   }
 
-  /** Normalize SQL for keyword matching: strip comments, uppercase, collapse whitespace */
+  /**
+   * Normalize SQL for keyword matching: strip comments, uppercase, collapse whitespace.
+   *
+   * Note: nested block comments (e.g. /‌* /‌* inner *‌/ outer *‌/) are not fully handled —
+   * the lazy regex may leave trailing comment text as SQL. This errs on the side of
+   * over-blocking (false positives), which is the safe default. The primary defence
+   * is always the PostgreSQL read-only role, not this blocklist.
+   */
   private _normalize(sql: string): string {
     return sql
       .replace(/--[^\n]*/g, " ") // strip line comments
-      .replace(/\/\*[\s\S]*?\*\//g, " ") // strip block comments
+      .replace(/\/\*[\s\S]*?\*\//g, " ") // strip block comments (non-nested)
       .toUpperCase()
       .replace(/\s+/g, " ")
       .trim();

--- a/src/tools/execute-query.ts
+++ b/src/tools/execute-query.ts
@@ -8,12 +8,13 @@ import { toolError } from "../utils/tool-result.js";
 import { envEnum } from "../utils/env-enum.js";
 
 const SQL_PREVIEW_MAX = 500;
+const DEFAULT_HITL_TIMEOUT_MS = 60_000;
 
-/** Truncate SQL for display in the elicitation prompt */
+/** Truncate and sanitize SQL for display in the elicitation prompt */
 function sqlPreview(sql: string): string {
-  const trimmed = sql.trim();
-  if (trimmed.length <= SQL_PREVIEW_MAX) return trimmed;
-  return trimmed.slice(0, SQL_PREVIEW_MAX) + "\n… (truncated)";
+  const sanitized = sql.trim().replace(/`/g, "\\`");
+  if (sanitized.length <= SQL_PREVIEW_MAX) return sanitized;
+  return sanitized.slice(0, SQL_PREVIEW_MAX) + "\n… (truncated)";
 }
 
 export function registerExecuteQuery(
@@ -57,9 +58,18 @@ export function registerExecuteQuery(
       };
 
       try {
+        // Layer 2: keyword blocklist — fast-fail before bothering the user with HITL
+        if (validator) {
+          const check = validator.validate(sql, envConfig.permissions);
+          if (!check.ok) {
+            audit("blocked", { reason: check.reason });
+            throw new BlockedQueryError(check.reason);
+          }
+        }
+
         // Layer 3: HITL confirmation for environments that require it
         if (envConfig.approval === "hitl") {
-          const timeoutMs = validator?.hitlTimeoutMs ?? 60_000;
+          const timeoutMs = validator?.hitlTimeoutMs ?? DEFAULT_HITL_TIMEOUT_MS;
 
           let elicitResult: {
             action: string;

--- a/src/tools/pipeline.test.ts
+++ b/src/tools/pipeline.test.ts
@@ -256,9 +256,8 @@ describe("Safety pipeline — prod env, HITL required", () => {
       content: { confirmed: true },
     });
 
-    // With blocklist enabled, DELETE is caught AFTER HITL (since HITL runs first in the handler,
-    // then executeQuery runs the blocklist check). This tests the actual order in the pipeline.
-    // HITL env + read-only permissions → elicitation fires, user approves, then blocklist catches DELETE.
+    // Blocklist runs BEFORE HITL — no point asking the user to approve
+    // a query that will be rejected anyway.
     registerExecuteQuery(
       server as never,
       manager as never,
@@ -269,8 +268,8 @@ describe("Safety pipeline — prod env, HITL required", () => {
       sql: "DELETE FROM products WHERE id = 1",
     });
 
-    // HITL fires first, user approved, then blocklist catches it
-    expect(server.server.elicitInput).toHaveBeenCalledOnce();
+    // Blocklist catches DELETE before HITL fires
+    expect(server.server.elicitInput).not.toHaveBeenCalled();
     expect(pool.query).not.toHaveBeenCalled();
     expect(result.content[0].text).toContain("Blocked keyword");
   });


### PR DESCRIPTION
## Summary

Post-Phase 4 review fixes:

- **Blocklist before HITL** — keyword blocklist now runs before HITL elicitation, so users are never prompted to approve a query that will be blocked anyway (was: HITL first → user approves → blocklist rejects)
- **Escape backticks in SQL preview** — prevents markdown breakage in elicitation prompts when SQL contains triple backticks
- **`DEFAULT_HITL_TIMEOUT_MS` constant** — replaces inline `60_000` magic number
- **Document `_normalize()` nested comment limitation** — lazy regex doesn't handle PostgreSQL nested `/* */` comments, but errs on the safe side (over-blocks, never under-blocks)
- **Updated pipeline test** — asserts `elicitInput` is NOT called for blocked queries in HITL envs

## Test plan

- [x] 155 tests passing, no regressions
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)