### PR TITLE
chore: sync package-lock.json to v0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toad-tunnel-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toad-tunnel-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- Sync `package-lock.json` version field after bumping to 0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)