### PR TITLE
fix: add README to npm package, bump 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toad-tunnel-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Multi-environment PostgreSQL MCP router with SSH tunnel management",
   "type": "module",
   "main": "dist/index.js",
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "config/toad-tunnel.example.yaml",
+    "README.md",
     "CHANGELOG.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary

README was missing from npm package page. Added `README.md` explicitly to `files` whitelist in `package.json`. Bumped version to 0.1.2 for republish.

## Test plan

- [x] `npm pack --dry-run` shows `README.md` (3.6kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)